### PR TITLE
fix(spa): interceptLinks(document, router) — was missing root arg

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -81,7 +81,10 @@ const router = createRouter([
   { path: "/moderate", name: "moderate" },
   { path: "/admin",    name: "admin" },
 ]);
-interceptLinks(router);
+// interceptLinks signature is (root, router) — first arg is the DOM element to
+// listen on, second is the router. Passing only `router` made `root` = router,
+// which has no addEventListener → blank-page crash.
+interceptLinks(document, router);
 
 effect(() => {
   const r = router.currentRoute();


### PR DESCRIPTION
**t4bs.com is blank.** DevTools shows `Uncaught TypeError: e.addEventListener is not a function` from the bundled `Yt` (= interceptLinks). The signature is `(root, router)` — main.js passed only the router, so `root` = router (no addEventListener) → crash during init → SPA never mounts.

Trivial fix: pass `document` as root. Verify post-deploy by loading t4bs.com.