### PR TITLE
fix(spa): /play hard-reload bounces to lobby instead of stuck loading

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -81,7 +81,10 @@ const router = createRouter([
   { path: "/moderate", name: "moderate" },
   { path: "/admin",    name: "admin" },
 ]);
-interceptLinks(router);
+// interceptLinks signature is (root, router) — first arg is the DOM element to
+// listen on, second is the router. Passing only `router` made `root` = router,
+// which has no addEventListener → blank-page crash.
+interceptLinks(document, router);
 
 effect(() => {
   const r = router.currentRoute();

--- a/src/main.js
+++ b/src/main.js
@@ -143,13 +143,23 @@ api.me().then(r => user.set(r.user)).catch(() => {});
   if (saved?.sessionId) {
     try {
       const s = await api.resumeSession(saved.sessionId);
-      if (s.error || s.finished) { await clearPersisted(SESSION_KEY); return; }
-      hydrateSession(s, /* fresh */ false);
-      router.navigate("/play");
-      toaster("RESUMED — pick up where you left off", "good");
+      if (s.error || s.finished) {
+        await clearPersisted(SESSION_KEY);
+      } else {
+        hydrateSession(s, /* fresh */ false);
+        router.navigate("/play");
+        toaster("RESUMED — pick up where you left off", "good");
+        return;
+      }
     } catch {
       await clearPersisted(SESSION_KEY);
     }
+  }
+
+  // Hard-reload on /play with no resumable session: bounce home so the
+  // user picks a round instead of staring at "loading round…" forever.
+  if (window.location.pathname === "/play" && !session()) {
+    router.navigate("/");
   }
 })();
 


### PR DESCRIPTION
## Summary
- Hard-reload (or any direct nav) to `/play` left users staring at "LOADING ROUND…" forever — `view='playing'` was set by the route but no session existed.
- After the resume IIFE finishes, if we're still on `/play` with no hydrated session, redirect to `/` so the user picks a round.

## Test plan
- [x] `vite build` clean (no console errors)
- [x] `vite preview` + manual: navigate to `/play` → lands on lobby with header rendering correctly
- [x] `npm run lint` + `npm run typecheck` pass
- [ ] Verify post-deploy: `https://t4bs.com/play` (hard reload) shows lobby, not stuck loading state

🤖 Generated with [Claude Code](https://claude.com/claude-code)