### PR TITLE
fix(spa): bundle keyboard CSS + mobile-web-app-capable meta

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
     <meta name="twitter:image:alt" content="Tabs — quick category puzzles" />
 
     <!-- iOS / web app -->
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Tabs" />

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@
    - Game core: shared/engine.js (untouched) via /api/* endpoints. */
 
 import "./styles.css";
+import "@basenative/keyboard/styles.css";
 
 import { signal, effect } from "@basenative/runtime";
 import { createRouter, interceptLinks } from "@basenative/router";

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,6 +18,18 @@ export default defineConfig({
       { find: /^\.\.\/\.\.\/\.\.\/src\/shared\/expression\.js$/, replacement: expressionShim },
     ],
   },
+  optimizeDeps: {
+    esbuildOptions: {
+      plugins: [
+        {
+          name: "shim-bn-expression",
+          setup(build) {
+            build.onResolve({ filter: /^\.\.\/\.\.\/\.\.\/src\/shared\/expression\.js$/ }, () => ({ path: expressionShim }));
+          },
+        },
+      ],
+    },
+  },
   plugins: [
     {
       name: "tabs-mock-api",


### PR DESCRIPTION
## Summary
- The on-screen QWERTY keyboard rendered with no styling — keys collapsed to default \`<button>\` sizing because @basenative/keyboard's stylesheet was never imported. Visible in production as a tiny cluster of unstyled letters in the bottom-left corner.
- Added \`mobile-web-app-capable\` meta tag (apple-mobile-web-app-capable is deprecated per the recent Chrome console warning).
- Wired the expression-shim alias into vite optimizeDeps so dev mode starts cleanly (was already fine in prod via tree-shaking).

## Test plan
- [x] Verified locally with vite dev (mock API): keyboard renders full QWERTY with proper key sizing, ENT highlighted, backspace icon
- [x] \`npm run lint\`, \`npm run typecheck\` (no changes here)
- [x] \`vite build\` clean — CSS bundle grew from 17KB → 20KB (keyboard styles)
- [ ] Verify post-deploy: load https://t4bs.com, pick a round, confirm keyboard renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)