### PR TITLE
feat: flip SSR gate — SSR is now the default, ?legacy=1 is the escape

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,16 +1,18 @@
-/* Top-level middleware: SSR dispatch (?next=1) + security headers +
-   no-store for API responses. */
+/* Top-level middleware: SSR dispatch (default) + ?legacy=1 escape +
+   security headers + no-store for API responses. */
 
-import { shouldRenderNext } from "../src/next/route-table.js";
+import { shouldRenderSsr } from "../src/next/route-table.js";
 import { renderSsr } from "./_shared/ssr.js";
 
 export const onRequest = async (ctx) => {
   const { request, next } = ctx;
   const url = new URL(request.url);
 
-  // ── SSR path: ?next=1 on a routable view ─────────────────────────────
-  // Only intercept GET — POSTs to /api/* must still flow through Functions.
-  if (request.method === "GET" && shouldRenderNext(url.pathname, url.searchParams)) {
+  // ── SSR is the default ───────────────────────────────────────────────
+  // `?legacy=1` is the escape hatch back to the client-only SPA at
+  // dist/index.html. Only intercept GET — POSTs to /api/* must still
+  // flow through Functions.
+  if (request.method === "GET" && shouldRenderSsr(url.pathname, url.searchParams)) {
     try {
       const ssr = await renderSsr(ctx);
       if (ssr) return decorate(ssr, url);

--- a/src/next/client/main.js
+++ b/src/next/client/main.js
@@ -89,17 +89,6 @@ const router = createRouter([
 ]);
 interceptLinks(document, router);
 
-// Strip ?next=1 from internal navigations so the SSR-vs-SPA gate is
-// orthogonal to the URL the user sees after the first paint.
-const stripNext = () => {
-  const url = new URL(window.location.href);
-  if (url.searchParams.has("next")) {
-    url.searchParams.delete("next");
-    window.history.replaceState(null, "", url.pathname + (url.search || "") + url.hash);
-  }
-};
-stripNext();
-
 effect(() => {
   const r = router.currentRoute();
   if (r.name === "lobby")         view.set("lobby");

--- a/src/next/next.test.js
+++ b/src/next/next.test.js
@@ -6,7 +6,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import { esc, escJson, join } from "./util/escape.js";
-import { matchRoute, shouldRenderNext } from "./route-table.js";
+import { matchRoute, shouldRenderSsr } from "./route-table.js";
 import { renderPage } from "./server/render.js";
 
 const ASSETS = { js: "/assets/next-hydrate.js", css: ["/assets/app.css"] };
@@ -58,18 +58,34 @@ describe("matchRoute", () => {
   });
 });
 
-describe("shouldRenderNext", () => {
-  it("requires ?next=1", () => {
-    assert.equal(shouldRenderNext("/", new URLSearchParams()), false);
-    assert.equal(shouldRenderNext("/", new URLSearchParams("next=1")), true);
+describe("shouldRenderSsr", () => {
+  it("defaults to SSR for routable views (no flag needed)", () => {
+    assert.equal(shouldRenderSsr("/",         new URLSearchParams()), true);
+    assert.equal(shouldRenderSsr("/play",     new URLSearchParams()), true);
+    assert.equal(shouldRenderSsr("/submit",   new URLSearchParams()), true);
+    assert.equal(shouldRenderSsr("/moderate", new URLSearchParams()), true);
+    assert.equal(shouldRenderSsr("/admin",    new URLSearchParams()), true);
   });
-  it("opts out for API/OG/share/asset paths", () => {
-    const qs = new URLSearchParams("next=1");
-    assert.equal(shouldRenderNext("/api/puzzles",   qs), false);
-    assert.equal(shouldRenderNext("/og/default.png",qs), false);
-    assert.equal(shouldRenderNext("/s/abc",         qs), false);
-    assert.equal(shouldRenderNext("/assets/x.js",   qs), false);
-    assert.equal(shouldRenderNext("/favicon.svg",   qs), false);
+  it("opts out when ?legacy=1 is set", () => {
+    assert.equal(shouldRenderSsr("/",     new URLSearchParams("legacy=1")), false);
+    assert.equal(shouldRenderSsr("/play", new URLSearchParams("legacy=1")), false);
+  });
+  it("ignores unrelated query params", () => {
+    assert.equal(shouldRenderSsr("/",     new URLSearchParams("foo=bar")),     true);
+    assert.equal(shouldRenderSsr("/play", new URLSearchParams("play=42")),     true);
+    assert.equal(shouldRenderSsr("/",     new URLSearchParams("legacy=true")), true);
+    assert.equal(shouldRenderSsr("/",     new URLSearchParams("legacy=0")),    true);
+  });
+  it("never intercepts API / OG / share / asset paths, even without ?legacy", () => {
+    const empty = new URLSearchParams();
+    assert.equal(shouldRenderSsr("/api/puzzles",        empty), false);
+    assert.equal(shouldRenderSsr("/og/default.png",     empty), false);
+    assert.equal(shouldRenderSsr("/s/abc",              empty), false);
+    assert.equal(shouldRenderSsr("/assets/x.js",        empty), false);
+    assert.equal(shouldRenderSsr("/asset-manifest.json",empty), false);
+    assert.equal(shouldRenderSsr("/favicon.svg",        empty), false);
+    assert.equal(shouldRenderSsr("/robots.txt",         empty), false);
+    assert.equal(shouldRenderSsr("/sitemap.xml",        empty), false);
   });
 });
 

--- a/src/next/route-table.js
+++ b/src/next/route-table.js
@@ -22,13 +22,18 @@ export function matchRoute(pathname) {
   return "not-found";
 }
 
+/* SSR is the default. `?legacy=1` is the escape hatch back to the
+   client-only SPA shell at dist/index.html. Asset / API / OG / share
+   paths always fall through to their own handlers so the SSR worker
+   never intercepts them. */
 /** @param {string} pathname @param {URLSearchParams} search */
-export function shouldRenderNext(pathname, search) {
-  if (search.get("next") !== "1") return false;
+export function shouldRenderSsr(pathname, search) {
+  if (search.get("legacy") === "1") return false;
   if (pathname.startsWith("/api/")) return false;
   if (pathname.startsWith("/og/"))  return false;
   if (pathname.startsWith("/s/"))   return false;
   if (pathname.startsWith("/assets/")) return false;
+  if (pathname === "/asset-manifest.json") return false;
   if (pathname === "/favicon.svg" || pathname === "/robots.txt" || pathname === "/sitemap.xml") return false;
   return true;
 }


### PR DESCRIPTION
## Summary

- Follow-up to #34 (M3). SSR is now the default code path for every routable GET; the legacy client-only SPA at \`dist/index.html\` is reachable via the \`?legacy=1\` escape hatch.
- Renamed \`shouldRenderNext\` → \`shouldRenderSsr\` and inverted the predicate. Same hard exclusions (\`/api/\`, \`/og/\`, \`/s/\`, \`/assets/\`, \`/asset-manifest.json\`, \`/favicon.svg\`, \`/robots.txt\`, \`/sitemap.xml\`) — those always fall through to their own handlers, with or without \`?legacy\`.
- Removed \`stripNext()\` from the hydration entry — \`?next=1\` is no longer the gate, and \`?legacy=1\` can never appear in a hydrated response. One less side-effect at boot.
- Test suite expanded 22 → 24: added cases for the default-true behavior, the literal-\"1\" requirement (\`legacy=true\` and \`legacy=0\` should NOT opt out), and that path exclusions hold even without \`?legacy\`.

## Why now

\`?next=1\` was the right gate for shipping M3 as a dark-launch (so the team could verify SSR/hydration without touching the SPA's blast radius). With the smoke tests + browser verification from #34 as evidence the SSR path works, flipping the default trades the dark-launch posture for the actual win — every visitor (including crawlers) gets the server-rendered HTML, and only an explicit opt-out keeps the legacy code path on the table.

The escape hatch matters: if a SSR/hydration regression surfaces post-deploy, a query-param toggle is a one-character workaround the user (or a debugging engineer) can apply without a redeploy. Cheaper than reverting #34 + this PR.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npx eslint src functions\` — clean
- [x] \`npm run build\` — produces \`dist/asset-manifest.json\` + \`dist/assets/next-hydrate-*.js\`
- [x] \`node --test src/next/next.test.js\` — 24/24 (was 22; +2 gate-flip cases)
- [x] \`node --test shared/engine.test.js\` — 54/54 (engine untouched)
- [x] \`wrangler pages dev dist\` + populated local D1 — verified via curl:
  - \`GET /\` → 200, \`X-T4BS-SSR: next\`, 10 puzzles in HTML
  - \`GET /?legacy=1\` → 200, NO \`X-T4BS-SSR\` header (legacy fall-through)
  - \`GET /play?play=2\` → 200, \`X-T4BS-SSR: next\`, session id + word lengths in DOM markers
  - \`GET /play?legacy=1\` → 200, NO \`X-T4BS-SSR\` (legacy)
  - \`GET /api/puzzles\` → 200, JSON, NO \`X-T4BS-SSR\`
  - \`GET /favicon.svg\` → 200, image/svg+xml, NO \`X-T4BS-SSR\`
  - \`GET /asset-manifest.json\` → 200, JSON manifest served (so \`loadAssets()\` resolves)
- [x] Browser-verified both paths in Chrome:
  - Default \`/\`: \`window.__T4BS_SSR__\` populated, \`next-hydrate-*.js\` loaded, 10 lobby buttons live, no console errors
  - \`/?legacy=1\`: no \`__T4BS_SSR__\` injected, \`index-*.js\` (legacy entry) loaded, 10 lobby buttons (fetched via /api/puzzles), no console errors
- [ ] Verify SSR remains default + \`?legacy=1\` works in production (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)