### PR TITLE
chore(deploy): migrate to reusable cf-deploy + d1-migrate workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,67 +8,27 @@ on:
 permissions:
   contents: read
   deployments: write
-  packages: read   # to install @basenative/* from GitHub Packages
+  packages: read
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: https://t4bs.com
-    steps:
-      - uses: actions/checkout@v6
+    uses: DuganLabs/.github/.github/workflows/cf-deploy.yml@v1
+    with:
+      project-name: t4bs
+      package-manager: npm
+      environment: production
+      environment-url: https://t4bs.com
+    secrets:
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v4
-
-      - name: Install dependencies
-        env:
-          # Pulls @basenative/* from GitHub Packages. GITHUB_TOKEN has
-          # packages:read for repos in the same org by default.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
-          npm ci
-
-      - name: Build
-        run: npm run build
-
-      # Deploy with Cloudflare credentials sourced from Doppler.
-      # Doppler secrets required:
-      #   CLOUDFLARE_API_TOKEN  – Pages:Edit + D1:Edit scope
-      #   CLOUDFLARE_ACCOUNT_ID – your Cloudflare account ID
-      - name: Deploy to Cloudflare Pages
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-        run: |
-          doppler run -- npx wrangler pages deploy dist \
-            --project-name=t4bs \
-            --branch=main \
-            --commit-dirty=true
-
-  # Apply schema changes on push to main. Idempotent (CREATE TABLE IF NOT EXISTS).
   migrate:
-    runs-on: ubuntu-latest
     needs: deploy
     if: github.event_name == 'push'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with: { node-version: 20, cache: npm }
-      - uses: dopplerhq/cli-action@v4
-      - name: Install dependencies
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
-          npm ci
-      - name: Apply D1 schema (idempotent)
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-        run: doppler run -- npx wrangler d1 execute tabs-db --remote --file=./schema.sql
+    uses: DuganLabs/.github/.github/workflows/d1-migrate.yml@v1
+    with:
+      database: tabs-db
+      package-manager: npm
+    secrets:
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace inline deploy + migrate jobs with thin callers to \`DuganLabs/.github/.github/workflows/cf-deploy.yml@v1\` and \`d1-migrate.yml@v1\`
- t4bs is now public, unblocking cross-repo reusable workflow access (the original blocker per [REUSABLE-WORKFLOWS-ACCESS.md](https://github.com/DuganLabs/duganlabs/blob/main/docs/REUSABLE-WORKFLOWS-ACCESS.md))
- Migration step now uses \`wrangler d1 migrations apply\` (state-tracked via \`d1_migrations\` table), replacing the prior direct \`schema.sql\` apply

Depends on DuganLabs/.github#7 (now merged + v1 retagged) which added optional \`NPM_TOKEN\` secret support to the reusable workflows for GitHub Packages auth.

Closes #8

## Test plan
- [ ] Push to main triggers reusable cf-deploy → builds + deploys to https://t4bs.com cleanly
- [ ] Migrate job applies any pending D1 migrations idempotently

🤖 Generated with [Claude Code](https://claude.com/claude-code)