### PR TITLE
Migrate deploy.yml to reusable workflows + drop dead prefetch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,74 +1,37 @@
 name: deploy
 
+# Thin caller: delegates to DuganLabs org-wide reusable workflows.
+# Cloudflare credentials live in Doppler; the caller passes the project id.
+#
+# Reusables (DuganLabs/.github @v1):
+#   .github/workflows/cf-deploy.yml   — build + wrangler pages deploy
+#   .github/workflows/d1-migrate.yml  — wrangler d1 migrations apply (idempotent)
+
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  deployments: write
-  packages: read   # to install @basenative/* from GitHub Packages
-
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: https://t4bs.com
-    steps:
-      - uses: actions/checkout@v6
+    uses: DuganLabs/.github/.github/workflows/cf-deploy.yml@v1
+    with:
+      project-name: t4bs
+      package-manager: npm
+      branch: main
+      environment: production
+      environment-url: https://t4bs.com
+    secrets:
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v4
-
-      - name: Install dependencies
-        env:
-          # Pulls @basenative/* from GitHub Packages. GITHUB_TOKEN has
-          # packages:read for repos in the same org by default.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
-          npm ci
-
-      - name: Build
-        run: npm run build
-
-      # Deploy with Cloudflare credentials sourced from Doppler.
-      # Doppler secrets required:
-      #   CLOUDFLARE_API_TOKEN  – Pages:Edit + D1:Edit scope
-      #   CLOUDFLARE_ACCOUNT_ID – your Cloudflare account ID
-      - name: Deploy to Cloudflare Pages
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-        run: |
-          doppler run -- npx wrangler pages deploy dist \
-            --project-name=t4bs \
-            --branch=main \
-            --commit-dirty=true
-
-  # Apply schema changes on push to main. Idempotent (CREATE TABLE IF NOT EXISTS).
   migrate:
-    runs-on: ubuntu-latest
     needs: deploy
     if: github.event_name == 'push'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with: { node-version: 20, cache: npm }
-      - uses: dopplerhq/cli-action@v4
-      - name: Install dependencies
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
-          npm ci
-      - name: Apply D1 schema (idempotent)
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-        run: doppler run -- npx wrangler d1 execute tabs-db --remote --file=./schema.sql
+    uses: DuganLabs/.github/.github/workflows/d1-migrate.yml@v1
+    with:
+      database: tabs-db
+      package-manager: npm
+    secrets:
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/index.html
+++ b/index.html
@@ -46,8 +46,6 @@
     <link rel="preload" as="image" href="/favicon.svg" type="image/svg+xml" imagesrcset="/favicon.svg" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/favicon.svg" />
-    <!-- Prefetch shared worker bundle for faster game load -->
-    <link rel="prefetch" href="/src/lib/game.js" as="script" />
 
     <!-- Font hosting: preconnect + dns-prefetch optimize font load times.
          display=swap on all fonts ensures text is always visible while custom


### PR DESCRIPTION
Two roadmap items, both code-fixable, bundled because they're small.

## Closes #8 — deploy.yml on reusable workflows

The previous block was *t4bs is private; reusable workflow lives in a public repo; GitHub blocks the call* (per `duganlabs/docs/REUSABLE-WORKFLOWS-ACCESS.md`). t4bs is now public, so Option A from that doc is satisfied — the thin caller works.

This PR replaces the inline 74-line checkout/setup-node/install/build/deploy/migrate flow with calls into:

- `DuganLabs/.github/.github/workflows/cf-deploy.yml@v1` — build + `wrangler pages deploy`
- `DuganLabs/.github/.github/workflows/d1-migrate.yml@v1` — `wrangler d1 migrations apply` (idempotent)

`package-manager: npm` is passed explicitly (the reusables default to pnpm). Doppler + GitHub Packages tokens are forwarded as `secrets`.

**Note:** the migrate job now uses `wrangler d1 migrations apply` against the `migrations/` dir, instead of the prior `wrangler d1 execute --file=./schema.sql`. The migration tracking table makes re-runs no-ops, and `migrations/0001_*` and `0002_*` already exist — so this is a strict improvement (the old job would have re-run schema.sql idempotently but never picked up new migration files).

## Helps #10 — drop dead `/src/lib/game.js` prefetch

`index.html` had `<link rel="prefetch" href="/src/lib/game.js" as="script" />`. In production, Vite resolved this through its module graph and inlined the source as a base64 `data:` URI on the prefetch link — a ~1.5 KB string that has no relation to the actual hashed bundle the runtime loads (`/assets/admin-*.js`).

Net effect: wasted bytes, a stale snapshot of source code in the HTML, no perf win. Removing it leaves the modulepreload Vite emits automatically, which targets the right hashed file.

Doesn't close #10 — that's the full Lighthouse / axe-core polish pass — but removes one obvious wart.

## Test plan

- [x] `npm run build` — clean (5.64 KB index.html, 16 KB gzipped main bundle)
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] Confirmed `dist/index.html` no longer contains the base64 `data:` prefetch link
- [ ] Manual: confirm next `gh run` after merge picks up the reusable workflow and deploys cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)