### PR TITLE
fix(play): iPhone keyboard taps not registering

### DIFF
--- a/src/views/play.js
+++ b/src/views/play.js
@@ -529,7 +529,19 @@ export function createPlay({
   // Hydrate the keyboard once it's in the tree.
   queueMicrotask(() => {
     const root = kbHost.querySelector('[data-bn="keyboard"]');
-    if (root) kb.hydrate(root);
+    if (!root) return;
+    kb.hydrate(root);
+    // iPhone workaround: @basenative/keyboard@1.0.0's preventFocusSteal
+    // calls preventDefault on touchstart, which on iOS Safari suppresses
+    // the synthetic click that the keyboard's dispatch handler relies on.
+    // Synthesize a click on touchend so the dispatch fires on iPhone.
+    // Drop this once the package bumps to 1.0.1 (fix lands upstream).
+    root.addEventListener("touchend", (e) => {
+      const btn = e.target && e.target.closest && e.target.closest("[data-bn-kb-key]");
+      if (!btn || btn.disabled) return;
+      e.preventDefault();
+      btn.click();
+    }, { passive: false });
   });
 
   // ── End-state overlays ──


### PR DESCRIPTION
## The bug

The on-screen keyboard on t4bs.com doesn't respond to touch on iPhone. Desktop clicks fine.

## Root cause

\`@basenative/keyboard@1.0.0\`'s \`preventFocusSteal\` (in [a11y.js](https://github.com/DuganLabs/basenative/blob/main/packages/keyboard/src/a11y.js)) calls \`e.preventDefault()\` on \`touchstart\` to keep text inputs focused when the user taps a virtual key. On iOS Safari, that ALSO suppresses the synthetic \`click\` event that the keyboard's dispatch handler relies on — so tapping a virtual key on iPhone silently does nothing. Desktop is unaffected because \`mousedown.preventDefault\` doesn't suppress click.

## Fix (downstream workaround)

After \`kb.hydrate(root)\` in \`src/views/play.js\`, attach a \`touchend\` listener that synthesizes a \`click\` on the tapped key via \`btn.click()\`. The keyboard's existing click dispatcher then fires \`onKey\`/\`onAction\` normally. The synthesized click is programmatic so it bypasses Safari's iOS suppression.

This is intentionally a downstream workaround. The proper fix landed upstream in \`@basenative/keyboard@1.0.1\` (DuganLabs/basenative#84) — \`hydrateKeyboard\` now listens on \`touchend\` in addition to \`click\`. Drop this block in t4bs once we bump to \`^1.0.1\` (waiting on the GH Packages publish).

## Verification

- \`npm run lint\` — clean
- \`npm run typecheck\` — clean
- \`npm run build\` — clean (admin chunk 57.87 kB / 19.27 kB gzip; +0.17 kB for the touchend handler)
- The new code path uses \`querySelector + closest('[data-bn-kb-key]')\` to match the same DOM contract \`hydrateKeyboard\` uses, so it dispatches on the same buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)