### PR TITLE
fix(play): kill the "Loading round…" zombie on reload

### DIFF
--- a/src/bn/client/hydrate.js
+++ b/src/bn/client/hydrate.js
@@ -34,6 +34,7 @@ import { createPlay }     from "../../views/play.js";
 import { createSubmit }   from "../../views/submit.js";
 import { createModerate } from "../../views/moderate.js";
 import { createAdmin }    from "../../views/admin.js";
+import { decidePlayBoot, withTimeout, isResumable } from "./play-boot.js";
 
 /** @typedef {import("../route-table.js").RouteName} RouteName */
 
@@ -90,6 +91,19 @@ const lives         = signal(4);
 const tokens        = signal(0);
 const phase         = signal("lobby");
 const reveal        = signal(null);
+
+/* Distinguishes "we are actively trying to resolve a session" from
+   "we definitively have no session". Without this the view effect can't
+   tell whether to show "Loading round…" or to bounce home, and a stalled
+   resume leaves the user staring at the loader forever. Seeded `true`
+   only when the SSR-rendered route is /play; every other entry point
+   starts the user away from the play view. */
+const playLoading = signal(SSR.route === "play");
+
+/* Bound on resume failure so the resume timeout / network error etc.
+   can be communicated as a toast without coupling the boot routine to
+   the toaster's lifetime. */
+const RESUME_TIMEOUT_MS = 8000;
 
 const toaster = makeToaster(toast);
 
@@ -150,47 +164,52 @@ if (!SSR.user) {
 }
 
 /* Reload-safe play-route resume.
-   On a fresh GET to /play (e.g. browser refresh, deep-link), the
-   server has no session context. We resolve it client-side, in
-   priority order:
-     1. ?play=<id> query param — start a new round on that puzzle.
-     2. A persisted session id — resume it via /api/sessions/:id.
-     3. Nothing → bounce to / so the user picks something.
-   Without this block, refreshing /play used to show "loading round…"
-   indefinitely (or bounce silently to /), which is what the user
-   reported as "page reload broken". */
+
+   Boot policy (decidePlayBoot) is a pure function in play-boot.js —
+   easier to test and harder to leave in the half-finished state that
+   PR #43 shipped. Every failure path here MUST end with either a
+   hydrated session or a navigate-home; falling through with both
+   `session()` null and `playLoading()` true is the bug we're fixing. */
 (async () => {
-  const url = new URL(window.location.href);
-  const playParam = url.searchParams.get("play");
-  const playId = playParam ? Number(playParam) : NaN;
-  if (Number.isFinite(playId) && playId > 0) {
-    url.searchParams.delete("play");
-    window.history.replaceState(null, "", url.pathname + (url.search || "") + url.hash);
-    await start(playId);
-    return;
-  }
+  try {
+    const saved = await loadPersisted(SESSION_KEY).catch(() => null);
+    const intent = decidePlayBoot(window.location, saved);
 
-  const saved = await loadPersisted(SESSION_KEY);
-  if (saved?.sessionId) {
-    try {
-      const s = await api.resumeSession(saved.sessionId);
-      if (s.error || s.finished) {
-        await clearPersisted(SESSION_KEY);
-      } else {
-        hydrateSession(s, /* fresh */ false);
-        if (window.location.pathname !== "/play") {
-          router.navigate("/play");
-        }
-        toaster("RESUMED — pick up where you left off", "good");
-        return;
-      }
-    } catch {
-      await clearPersisted(SESSION_KEY);
+    if (intent.kind === "start") {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("play");
+      window.history.replaceState(null, "", url.pathname + (url.search || "") + url.hash);
+      await start(intent.puzzleId);
+      return;
     }
-  }
 
-  if (window.location.pathname === "/play" && !session()) {
-    router.navigate("/");
+    if (intent.kind === "resume") {
+      try {
+        const s = await withTimeout(
+          api.resumeSession(intent.sessionId),
+          RESUME_TIMEOUT_MS,
+          "resume-timeout",
+        );
+        if (isResumable(s)) {
+          hydrateSession(s, /* fresh */ false);
+          if (window.location.pathname !== "/play") router.navigate("/play");
+          toaster("RESUMED — pick up where you left off", "good");
+          return;
+        }
+        await clearPersisted(SESSION_KEY).catch(() => {});
+      } catch (e) {
+        await clearPersisted(SESSION_KEY).catch(() => {});
+        const code = /** @type {{ code?: string }} */ (e)?.code;
+        if (code === "ETIMEOUT") toaster("Couldn't reach the server — try again.", "bad");
+      }
+    }
+
+    /* "home" intent OR resume failed/expired: get the user off /play.
+       Previously this relied on a fall-through `if (!session()) navigate("/")`
+       check that never ran when the resume promise stalled forever. */
+    if (window.location.pathname === "/play") router.navigate("/");
+  } finally {
+    playLoading.set(false);
   }
 })();
 
@@ -225,12 +244,15 @@ function hydrateSession(s, fresh) {
 async function start(puzzleId) {
   error.set(null);
   try {
-    const s = await api.startSession(puzzleId);
+    const s = await withTimeout(api.startSession(puzzleId), RESUME_TIMEOUT_MS, "start-timeout");
     hydrateSession(s, true);
     await savePersisted(SESSION_KEY, { sessionId: s.sessionId }, 12 * 3600);
     router.navigate("/play");
   } catch (e) {
-    error.set(String(e.message || e));
+    error.set(String(/** @type {Error} */ (e)?.message || e));
+    /* Don't strand the user on /play with no session — surface the
+       error on the lobby where the message + retry are visible. */
+    if (window.location.pathname === "/play") router.navigate("/");
   }
 }
 
@@ -358,7 +380,16 @@ effect(() => {
     }));
   } else if (v === "playing") {
     if (!session()) {
-      mount(viewSlot, h("p", { role: "status", "aria-live": "polite" }, "Loading round…"));
+      if (playLoading()) {
+        mount(viewSlot,
+          h("p", { role: "status", "aria-live": "polite" }, "Loading round…"),
+        );
+      } else {
+        /* Boot resolver gave up but route still says /play — flip back
+           to the lobby instead of dead-ending here. */
+        mount(viewSlot);
+        if (window.location.pathname === "/play") router.navigate("/");
+      }
       return;
     }
     mount(viewSlot, createPlay({

--- a/src/bn/client/play-boot.js
+++ b/src/bn/client/play-boot.js
@@ -1,0 +1,89 @@
+/* Pure boot-policy for the /play route.
+
+   Splitting this out from the hydrator buys us a unit-testable surface
+   for the "what should the client do when /play loads?" question. The
+   hydrator stays an imperative orchestrator; the *decision* lives here.
+
+   On a fresh GET to /play (refresh, deep-link, share-card click) the
+   server has no session context — sessions are mutating and we don't
+   create one per crawler hit. The client resolves it in priority order:
+
+     1. ?play=<id> in the URL — start a new round on that puzzle.
+     2. A saved session id in local storage — resume it.
+     3. Nothing → bounce home so the user picks a round.
+
+   Without this resolver the user used to stare at "Loading round…"
+   indefinitely (the symptom that PR #43 tried to fix and didn't). */
+
+/**
+ * @typedef {{ kind: "start", puzzleId: number }} StartIntent
+ * @typedef {{ kind: "resume", sessionId: string }} ResumeIntent
+ * @typedef {{ kind: "home" }} HomeIntent
+ * @typedef {StartIntent | ResumeIntent | HomeIntent} BootIntent
+ */
+
+/**
+ * Decide what the client should do when the /play route boots.
+ *
+ * @param {{ search: string, pathname?: string }} location  Just the bits of `Location` we read.
+ * @param {{ sessionId?: string } | null | undefined} saved Whatever `loadPersisted("t4bs:session")` returned.
+ * @returns {BootIntent}
+ */
+export function decidePlayBoot(location, saved) {
+  const params = new URLSearchParams(location.search || "");
+  const playRaw = params.get("play");
+  if (playRaw !== null) {
+    const playId = Number(playRaw);
+    if (Number.isFinite(playId) && playId > 0) {
+      return { kind: "start", puzzleId: playId };
+    }
+  }
+  if (saved && typeof saved.sessionId === "string" && saved.sessionId.length > 0) {
+    return { kind: "resume", sessionId: saved.sessionId };
+  }
+  return { kind: "home" };
+}
+
+/**
+ * Race a promise against a timeout. Rejects with a tagged error when the
+ * deadline elapses so callers can distinguish hangs from real failures.
+ *
+ * @template T
+ * @param {Promise<T>} promise
+ * @param {number} ms
+ * @param {string} [label]
+ * @returns {Promise<T>}
+ */
+export function withTimeout(promise, ms, label = "timeout") {
+  return new Promise((resolve, reject) => {
+    const id = setTimeout(() => {
+      const err = new Error(label);
+      /** @type {{ code: string }} */ (err).code = "ETIMEOUT";
+      reject(err);
+    }, ms);
+    promise.then(
+      (v) => { clearTimeout(id); resolve(v); },
+      (e) => { clearTimeout(id); reject(e); },
+    );
+  });
+}
+
+/**
+ * Treat a resumed session as usable iff it has the basic shape we need
+ * to render and isn't already finished. Engine returns `{ error: ... }`
+ * for not-found / puzzle-gone, and `finished: "won"|"lost"|true` for
+ * completed rounds — both are dead-ends for resume.
+ *
+ * @param {unknown} s
+ * @returns {boolean}
+ */
+export function isResumable(s) {
+  if (!s || typeof s !== "object") return false;
+  /** @type {Record<string, unknown>} */
+  const r = s;
+  if (r.error) return false;
+  if (r.finished) return false;
+  if (!Array.isArray(r.words) || r.words.length === 0) return false;
+  if (!Array.isArray(r.anchors)) return false;
+  return true;
+}

--- a/src/bn/hydrate.test.js
+++ b/src/bn/hydrate.test.js
@@ -12,6 +12,7 @@ import assert from "node:assert/strict";
 
 import { matchRoute, shouldRenderSsr } from "./route-table.js";
 import { renderPage } from "./server/render.js";
+import { decidePlayBoot, withTimeout, isResumable } from "./client/play-boot.js";
 
 const ASSETS = { js: "/assets/bn-hydrate.js", css: ["/assets/app.css"] };
 
@@ -172,5 +173,111 @@ describe("renderPage — emits a complete BaseNative-rendered HTML document for 
     assert.match(html, /\/assets\/bn-hydrate-abc123\.js/);
     assert.match(html, /\/assets\/app-def\.css/);
     assert.match(html, /\/assets\/bundle-456\.css/);
+  });
+
+  it("inlines the route name in SSR state for the hydrator", () => {
+    const html = renderPage(baseCtx({ route: "play", pathname: "/play" }), ASSETS);
+    const start = html.indexOf('<script type="application/json" id="bn-ssr-state">');
+    const end = html.indexOf("</script>", start);
+    const json = JSON.parse(html.slice(start, end).split(">")[1]);
+    assert.equal(json.route, "play");
+  });
+});
+
+describe("decidePlayBoot", () => {
+  it("starts a new round on ?play=<id>", () => {
+    const intent = decidePlayBoot({ search: "?play=42" }, null);
+    assert.deepEqual(intent, { kind: "start", puzzleId: 42 });
+  });
+
+  it("ignores ?play=<not-a-positive-int>", () => {
+    assert.equal(decidePlayBoot({ search: "?play=0" }, null).kind, "home");
+    assert.equal(decidePlayBoot({ search: "?play=-3" }, null).kind, "home");
+    assert.equal(decidePlayBoot({ search: "?play=abc" }, null).kind, "home");
+    assert.equal(decidePlayBoot({ search: "?play=" }, null).kind, "home");
+  });
+
+  it("resumes when a saved session id is present", () => {
+    const intent = decidePlayBoot({ search: "" }, { sessionId: "abc-123" });
+    assert.deepEqual(intent, { kind: "resume", sessionId: "abc-123" });
+  });
+
+  it("?play=<id> beats a saved session — explicit user intent wins", () => {
+    const intent = decidePlayBoot({ search: "?play=7" }, { sessionId: "abc-123" });
+    assert.deepEqual(intent, { kind: "start", puzzleId: 7 });
+  });
+
+  it("treats empty / malformed saved state as no resume", () => {
+    assert.equal(decidePlayBoot({ search: "" }, null).kind, "home");
+    assert.equal(decidePlayBoot({ search: "" }, undefined).kind, "home");
+    assert.equal(decidePlayBoot({ search: "" }, {}).kind, "home");
+    assert.equal(decidePlayBoot({ search: "" }, { sessionId: "" }).kind, "home");
+    assert.equal(decidePlayBoot({ search: "" }, { sessionId: 42 }).kind, "home");
+  });
+});
+
+describe("withTimeout", () => {
+  it("resolves when the inner promise resolves first", async () => {
+    const result = await withTimeout(Promise.resolve("ok"), 1000);
+    assert.equal(result, "ok");
+  });
+
+  it("rejects with code=ETIMEOUT when the deadline elapses", async () => {
+    const stalled = new Promise(() => { /* never resolves */ });
+    await assert.rejects(
+      () => withTimeout(stalled, 20, "test-timeout"),
+      (err) => {
+        assert.equal(err.code, "ETIMEOUT");
+        assert.equal(err.message, "test-timeout");
+        return true;
+      },
+    );
+  });
+
+  it("propagates inner-promise rejection unchanged", async () => {
+    const inner = Promise.reject(new Error("boom"));
+    await assert.rejects(
+      () => withTimeout(inner, 1000),
+      /boom/,
+    );
+  });
+});
+
+describe("isResumable", () => {
+  const valid = {
+    sessionId: "x",
+    words: [5, 5],
+    anchors: [{ wi: 0, li: 0, letter: "H" }],
+    lives: 4,
+    score: 0,
+    locked: { 0: { 0: "H" } },
+    presentGlobal: [],
+    absentByWord: [[], []],
+    wordSolved: [false, false],
+    finished: false,
+  };
+
+  it("accepts an in-progress session", () => {
+    assert.equal(isResumable(valid), true);
+  });
+
+  it("rejects engine errors", () => {
+    assert.equal(isResumable({ error: "no-session" }), false);
+    assert.equal(isResumable({ error: "puzzle-gone" }), false);
+  });
+
+  it("rejects finished sessions (game already over)", () => {
+    assert.equal(isResumable({ ...valid, finished: "won" }), false);
+    assert.equal(isResumable({ ...valid, finished: "lost" }), false);
+    assert.equal(isResumable({ ...valid, finished: true }), false);
+  });
+
+  it("rejects malformed shapes", () => {
+    assert.equal(isResumable(null), false);
+    assert.equal(isResumable(undefined), false);
+    assert.equal(isResumable("nope"), false);
+    assert.equal(isResumable({ ...valid, words: undefined }), false);
+    assert.equal(isResumable({ ...valid, words: [] }), false);
+    assert.equal(isResumable({ ...valid, anchors: undefined }), false);
   });
 });

--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,7 @@ import { createPlay } from "./views/play.js";
 import { createSubmit } from "./views/submit.js";
 import { createModerate } from "./views/moderate.js";
 import { createAdmin } from "./views/admin.js";
+import { decidePlayBoot, withTimeout, isResumable } from "./bn/client/play-boot.js";
 
 /* ── error logging (carryover from the React main) ─────────────────────── */
 function postLog(payload) {
@@ -72,6 +73,11 @@ const lives         = signal(4);
 const tokens        = signal(0);
 const phase         = signal("lobby");
 const reveal        = signal(null);
+/* True while the /play boot resolver is running — distinguishes
+   "still loading" from "definitively no session". */
+const playLoading   = signal(window.location.pathname === "/play");
+
+const RESUME_TIMEOUT_MS = 8000;
 
 const toaster = makeToaster(toast);
 
@@ -131,37 +137,43 @@ api.listPuzzles().then(lobby.set).catch(e => error.set(String(e.message || e)));
 api.me().then(r => user.set(r.user)).catch(() => {});
 
 (async () => {
-  const url = new URL(window.location.href);
-  const playParam = url.searchParams.get("play");
-  const playId = playParam ? Number(playParam) : NaN;
-  if (Number.isFinite(playId) && playId > 0) {
-    url.searchParams.delete("play");
-    window.history.replaceState(null, "", url.pathname + (url.search || "") + url.hash);
-    await start(playId);
-    return;
-  }
+  try {
+    const saved = await loadPersisted(SESSION_KEY).catch(() => null);
+    const intent = decidePlayBoot(window.location, saved);
 
-  const saved = await loadPersisted(SESSION_KEY);
-  if (saved?.sessionId) {
-    try {
-      const s = await api.resumeSession(saved.sessionId);
-      if (s.error || s.finished) {
-        await clearPersisted(SESSION_KEY);
-      } else {
-        hydrateSession(s, /* fresh */ false);
-        router.navigate("/play");
-        toaster("RESUMED — pick up where you left off", "good");
-        return;
-      }
-    } catch {
-      await clearPersisted(SESSION_KEY);
+    if (intent.kind === "start") {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("play");
+      window.history.replaceState(null, "", url.pathname + (url.search || "") + url.hash);
+      await start(intent.puzzleId);
+      return;
     }
-  }
 
-  // Hard-reload on /play with no resumable session: bounce home so the
-  // user picks a round instead of staring at "loading round…" forever.
-  if (window.location.pathname === "/play" && !session()) {
-    router.navigate("/");
+    if (intent.kind === "resume") {
+      try {
+        const s = await withTimeout(
+          api.resumeSession(intent.sessionId),
+          RESUME_TIMEOUT_MS,
+          "resume-timeout",
+        );
+        if (isResumable(s)) {
+          hydrateSession(s, /* fresh */ false);
+          router.navigate("/play");
+          toaster("RESUMED — pick up where you left off", "good");
+          return;
+        }
+        await clearPersisted(SESSION_KEY).catch(() => {});
+      } catch (e) {
+        await clearPersisted(SESSION_KEY).catch(() => {});
+        if (/** @type {{ code?: string }} */ (e)?.code === "ETIMEOUT") {
+          toaster("Couldn't reach the server — try again.", "bad");
+        }
+      }
+    }
+
+    if (window.location.pathname === "/play") router.navigate("/");
+  } finally {
+    playLoading.set(false);
   }
 })();
 
@@ -196,12 +208,13 @@ function hydrateSession(s, fresh) {
 async function start(puzzleId) {
   error.set(null);
   try {
-    const s = await api.startSession(puzzleId);
+    const s = await withTimeout(api.startSession(puzzleId), RESUME_TIMEOUT_MS, "start-timeout");
     hydrateSession(s, true);
     await savePersisted(SESSION_KEY, { sessionId: s.sessionId }, 12 * 3600);
     router.navigate("/play");
   } catch (e) {
-    error.set(String(e.message || e));
+    error.set(String(/** @type {Error} */ (e)?.message || e));
+    if (window.location.pathname === "/play") router.navigate("/");
   }
 }
 
@@ -327,8 +340,12 @@ effect(() => {
     }));
   } else if (v === "playing") {
     if (!session()) {
-      // Awaiting hydrate — show a minimal placeholder.
-      mount(viewSlot, h("div", { class: "lb-cred" }, "loading round…"));
+      if (playLoading()) {
+        mount(viewSlot, h("div", { class: "lb-cred" }, "loading round…"));
+      } else {
+        mount(viewSlot);
+        if (window.location.pathname === "/play") router.navigate("/");
+      }
       return;
     }
     mount(viewSlot, createPlay({


### PR DESCRIPTION
## Summary

Fix the `/play` hard-reload bug PR #43 didn't actually fix. The root cause is a stalled-promise deadlock, not just a fall-through bug:

- `api.resumeSession` had no fetch timeout — a network hang left the resume IIFE awaiting forever. The catch never fired, the fall-through `router.navigate("/")` never ran, and the view stuck on "Loading round…" until the user gave up.
- The view effect conflated "still resolving" with "definitively no session" (same "Loading round…" text covered both), so a stalled resume was indistinguishable from an in-flight one.

## What changed

- **New `src/bn/client/play-boot.js`** — pure boot policy as `decidePlayBoot(location, saved)`, plus `withTimeout` and `isResumable` helpers. Testable without jsdom; the orchestrator can't leave it in a half-finished state.
- **`src/bn/client/hydrate.js`**:
  - `playLoading` signal distinguishes "still loading" from "no session". When loading flips false with no session on `/play`, the view effect routes home instead of dead-ending.
  - IIFE wrapped in `try { … } finally { playLoading.set(false); }` so the loading flag flips off on every exit — return, throw, fall-through.
  - Every failure path explicitly calls `router.navigate("/")` instead of relying on a bottom-of-IIFE check that couldn't run when the resume await never resolved.
  - `withTimeout` (8s, `ETIMEOUT`-tagged) on `api.resumeSession` and `api.startSession` so a stalled server can't hang the boot. Network-failure case shows a toast.
- **`src/main.js`** — same treatment for the `?legacy=1` SPA shell so both code paths agree.

## Tests

`node --test src/bn/hydrate.test.js` — 34 tests pass:

- `decidePlayBoot`: `?play=N` → start, `saved.sessionId` → resume, otherwise home; `?play` wins over saved; malformed/empty saved → home.
- `withTimeout`: resolves on inner-promise success, rejects with `code=ETIMEOUT` on deadline, propagates inner rejection unchanged.
- `isResumable`: accepts in-progress session, rejects engine errors, rejects finished sessions (`"won"`/`"lost"`/`true`), rejects malformed shapes.
- `renderPage`: SSR state already inlines `route` so the hydrator can boot knowing which route the server picked (asserts the contract).

## Verification

- `npm run lint` — clean
- `npm run typecheck` — clean
- `node --test src/bn/hydrate.test.js` — 34/34 pass
- `node --test shared/engine.test.js` — 54/54 pass
- `npm run build` — clean, manifest emits `bn-hydrate` entry as expected
- Local preview cross-checked: SSR shell renders the @else fallback with the route name in `bn-ssr-state` JSON; hydrator picks it up.

## Test plan

- [ ] Hard-reload `/play` with NO saved session → bounces to `/` quickly (no "Loading round…" zombie).
- [ ] Hard-reload `/play` WITH a valid saved session → resumes the round, "RESUMED" toast.
- [ ] Hard-reload `/play` WITH a saved session whose row no longer exists in D1 → clears storage, bounces to `/`.
- [ ] Simulate a stalled `/api/session/:id` (devtools network throttle "offline" or 30s+ delay) → after 8s, toast "Couldn't reach the server", bounces to `/`. No infinite "Loading round…".
- [ ] `/play?play=3` deep-link → starts puzzle 3, history replaced to `/play`.
- [ ] `?legacy=1` SPA path: same four scenarios still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)