### PR TITLE
feat(ssr): make the lobby work with JavaScript disabled

### DIFF
--- a/src/bn/hydrate.test.js
+++ b/src/bn/hydrate.test.js
@@ -129,6 +129,44 @@ describe("renderPage — emits a complete BaseNative-rendered HTML document for 
     assert.match(html, /data-puzzle-ids="3"/);
   });
 
+  /* issue #24 — the lobby must work with JavaScript disabled. Each
+     puzzle group renders an <a href="/play?play=ID"> the SPA can
+     enhance after hydration, plus a <noscript> hint pitched at the
+     no-JS user. */
+  it("lobby renders anchor links to /play?play=<id> for each group", () => {
+    const lobby = [
+      { id: 7, category: "ANIMALS", submittedBy: "wmd" },
+      { id: 3, category: "ANIMALS", submittedBy: "warren" },
+      { id: 4, category: "FOODS",   submittedBy: "wmd" },
+    ];
+    const html = renderPage(baseCtx({ lobby }), ASSETS);
+    /* Multi-puzzle group: deterministic lowest-id pick (3 not 7). */
+    assert.match(html, /href="\/play\?play=3"/);
+    /* Single-puzzle group: the only id is the link target. */
+    assert.match(html, /href="\/play\?play=4"/);
+    /* No <button> for picking a round in the SSR markup — the
+       degradation contract is anchors only. */
+    const lobbyHtml = html.split("data-bn-view=\"lobby\"")[1] ?? "";
+    assert.ok(
+      !/<button[^>]*data-bn-action="lobby-pick"/.test(lobbyHtml),
+      "lobby SSR must not emit a <button> for picking — anchors only",
+    );
+  });
+
+  it("lobby includes a <noscript> hint about JS-optional play", () => {
+    const html = renderPage(baseCtx({
+      lobby: [{ id: 1, category: "ANIMALS", submittedBy: "wmd" }],
+    }), ASSETS);
+    assert.match(html, /<noscript>[\s\S]*JavaScript enhances[\s\S]*<\/noscript>/);
+  });
+
+  it("submit FAB degrades to an anchor for no-JS users", () => {
+    const html = renderPage(baseCtx({
+      lobby: [{ id: 1, category: "ANIMALS", submittedBy: "wmd" }],
+    }), ASSETS);
+    assert.match(html, /<a[^>]*href="\/submit"[^>]*data-bn-action="lobby-submit"/);
+  });
+
   it("play view shows word-length skeleton with anchor letters", () => {
     const play = {
       id: 42,

--- a/src/bn/server/render.js
+++ b/src/bn/server/render.js
@@ -60,16 +60,27 @@ function safeJson(value) {
     .replace(/\u2029/g, "\\u2029");
 }
 
-/** @param {{ category: string, submittedBy: string }[] | null} lobby */
+/** @param {{ id: number, category: string, submittedBy: string }[] | null} lobby */
 function lobbyGroups(lobby) {
   const groups = groupLobby(lobby) || [];
-  return groups.map(group => ({
-    category: group.category,
-    puzzleIds: group.puzzles.map(p => p.id).join(","),
-    credit: group.puzzles.length === 1
-      ? `by ${group.puzzles[0].submittedBy}`
-      : `${group.puzzles.length} puzzles`,
-  }));
+  return groups.map(group => {
+    /* For the no-JS case we need a deterministic single round per
+       category — pick the lowest puzzle id. The hydrated SPA uses a
+       random pick within the group instead, but that re-bind happens
+       after mount() replaces the SSR markup, so the link target only
+       affects browsers without JS or before the bundle has executed. */
+    const firstPuzzleId = group.puzzles
+      .map(p => p.id)
+      .reduce((min, id) => (id < min ? id : min), group.puzzles[0].id);
+    return {
+      category: group.category,
+      puzzleIds: group.puzzles.map(p => p.id).join(","),
+      playHref: `/play?play=${firstPuzzleId}`,
+      credit: group.puzzles.length === 1
+        ? `by ${group.puzzles[0].submittedBy}`
+        : `${group.puzzles.length} puzzles`,
+    };
+  });
 }
 
 /** @param {import('./ssr-context.js').PlaySessionSsr | null} play */

--- a/src/bn/views/lobby.js
+++ b/src/bn/views/lobby.js
@@ -1,11 +1,24 @@
 /* lobby.html — exported as a string for both worker and vite
    bundling. Edit this file to change the template; the .js wrapper
    keeps it portable across the @basenative/server SSR worker and
-   any node:test consumers. */
+   any node:test consumers.
+
+   Each round is rendered as a real <a href="/play?play={id}"> so the
+   lobby is usable with JavaScript disabled (issue #24). When the SPA
+   hydrates, mount() replaces #app's children with the imperative tree
+   that uses <button> + signal-driven onclick — so the anchors are a
+   purely SSR-time degradation surface, no hydration mismatch. */
 
 export default `<main aria-labelledby="lobby-title" data-bn-view="lobby">
   <h1 id="lobby-title">Pick a round</h1>
   <p>One subject. One phrase. No mercy.</p>
+
+  <noscript>
+    <p data-bn-region="noscript-hint">
+      JavaScript enhances this experience but isn't required to play —
+      pick a puzzle below to start a round.
+    </p>
+  </noscript>
 
   <section aria-labelledby="lobby-stats-title" data-bn-region="stats" hidden>
     <h2 id="lobby-stats-title">Your run</h2>
@@ -20,13 +33,13 @@ export default `<main aria-labelledby="lobby-title" data-bn-view="lobby">
     <ul role="list" data-bn-region="list">
       <template @for="group of groups; track group.category">
         <li>
-          <button type="button"
-                  data-bn-action="lobby-pick"
-                  :data-puzzle-ids="group.puzzleIds"
-                  :aria-label="'Play ' + group.category + ' — ' + group.credit">
+          <a :href="group.playHref"
+             data-bn-action="lobby-pick"
+             :data-puzzle-ids="group.puzzleIds"
+             :aria-label="'Play ' + group.category + ' — ' + group.credit">
             <strong>{{ group.category }}</strong>
             <small>{{ group.credit }}</small>
-          </button>
+          </a>
         </li>
       </template>
       <template @empty>
@@ -35,8 +48,8 @@ export default `<main aria-labelledby="lobby-title" data-bn-view="lobby">
     </ul>
   </section>
 
-  <button type="button" data-bn-action="lobby-submit" aria-label="Submit a phrase">
+  <a href="/submit" data-bn-action="lobby-submit" aria-label="Submit a phrase">
     + Submit a phrase
-  </button>
+  </a>
 </main>
 `;


### PR DESCRIPTION
Closes #24.

## Summary

The SSR-rendered lobby previously emitted `<button data-bn-action="…">` elements that did nothing without JS. With the SSR shell as the default shape served to crawlers and JS-off users, that meant a non-functional landing page.

Now each puzzle group renders an `<a href="/play?play=<id>">`. `hydrate.js` already resolves `?play=<id>` on `/play` boot (starts the named round, `replaceState`s the URL), so this works seamlessly across both modes.

## How it degrades

| | with JS | without JS |
| --- | --- | --- |
| Click in lobby | `mount()` has already replaced SSR markup; SPA `<button>` + onClick handles it | Real navigation to `/play?play=<id>` |
| Click during first paint (pre-hydrate) | Anchor navigation; `hydrate.js` handles `?play=<id>` on the next page identically to a SPA click | n/a |
| `/play` page | Hydrator picks up `?play=<id>` and starts the round | SSR renders the round skeleton: semantic `<main>`, `<h1>`, word-length grid with anchor letters. User can read but can't type. |

Lowest puzzle id wins as the link target for multi-puzzle categories. The SPA picks randomly inside the group, but that re-bind happens after `mount()`, so the SSR target only matters for the no-JS or pre-hydrate window. Lowest-id is deterministic for share-card stability and crawler caching.

The "+ Submit a phrase" FAB also degrades from `<button>` to `<a href="/submit">` — `/submit` is already SSR'd with a real `<form>` the SPA enhances after hydrate.

A short `<noscript>` hint inside the lobby tells the no-JS user the anchors are real and the experience is intentionally graceful, not broken.

## Tests

`node --test src/bn/hydrate.test.js` — 24/24 pass:

- Lobby renders `<a href="/play?play=N">` for each group.
- Multi-puzzle groups pick the lowest id deterministically.
- No `<button data-bn-action="lobby-pick">` appears in SSR output (anchors only is the contract).
- `<noscript>` block with the "JavaScript enhances this experience…" hint is rendered.
- Submit FAB is an `<a href="/submit">`.

## Verification

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run build` — clean
- Live preview: `GET /` returns 10 `/play?play=N` anchors + the noscript hint; `GET /play?play=3` returns the BEATLES SONGS round skeleton (4 words · 15 letters), fully readable with JS off.

## Test plan

- [ ] Disable JS in DevTools, load `/`, click any category — should land on `/play?play=N` with the SSR'd round skeleton visible.
- [ ] With JS on, hard-reload `/`, click before hydration finishes — should still land on `/play` and the round should start (hydrator handles `?play=<id>`).
- [ ] With JS on, normal click on a category — should start the round in-place via the SPA `<button>` + onClick path (no anchor navigation).
- [ ] Multi-puzzle category (e.g. one with `id=7` and `id=3`) — SSR href should be the lower id.
- [ ] View source on `/` — confirm the `<noscript>` hint is in the markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)