### PR TITLE
perf+a11y: lighthouse quick wins on t4bs.com

### DIFF
--- a/functions/_shared/ssr.js
+++ b/functions/_shared/ssr.js
@@ -31,74 +31,101 @@ export async function renderSsr({ request, env }) {
   const url = new URL(request.url);
   const route = matchRoute(url.pathname);
 
-  // Resolve current user once — header + admin/mod gates all need it.
+  /* Run the user lookup, the route-specific data fetch, and the asset
+     manifest read in parallel — they're all independent on a cold
+     request and were sequential before, costing one D1 round-trip per
+     hop on Lighthouse's TTFB. The user lookup is the only one we need
+     resolved before deciding whether moderate/admin are forbidden, so
+     we await the user-promise inside those branches but kick all
+     three off together. */
+
+  /** @type {Promise<typeof user>} */
+  const userPromise = (async () => {
+    try {
+      const u = await currentUser(request, env);
+      if (!u) return null;
+      return {
+        handle: u.handle,
+        role: getRole(u),
+        isAdmin: isAdmin(u),
+        isModerator: isModerator(u),
+      };
+    } catch { return null; }
+  })();
+
+  const assetsPromise = loadAssets(env, url);
+
+  /** @type {{ lobby: any[] | null, play: any, modPending: any[] | null, adminElevated: any[] | null }} */
+  const fetched = { lobby: null, play: null, modPending: null, adminElevated: null };
+  let dataError = null;
+
+  /** @type {Promise<unknown>} */
+  let dataPromise = Promise.resolve();
+
+  if (route === "lobby" || route === "submit") {
+    dataPromise = (async () => {
+      const engine = createEngine({
+        puzzles: d1Puzzles(env.DB),
+        sessions: d1Sessions(env.DB),
+      });
+      fetched.lobby = await engine.listPuzzles();
+    })();
+  } else if (route === "play") {
+    dataPromise = resolvePlay(env, url.searchParams).then(p => { fetched.play = p; });
+  } else if (route === "moderate") {
+    dataPromise = (async () => {
+      const u = await userPromise;
+      if (u && u.isModerator) fetched.modPending = await d1Submissions(env.DB).listPending();
+    })();
+  } else if (route === "admin") {
+    dataPromise = (async () => {
+      const u = await userPromise;
+      if (u && u.isAdmin) fetched.adminElevated = await d1Users(env.DB).listByRoles(["moderator", "admin"]);
+    })();
+  }
+
   let user = null;
   try {
-    const u = await currentUser(request, env);
-    if (u) user = {
-      handle: u.handle,
-      role: getRole(u),
-      isAdmin: isAdmin(u),
-      isModerator: isModerator(u),
-    };
-  } catch { /* anonymous */ }
+    [user] = await Promise.all([userPromise, dataPromise.catch(e => { dataError = e; })]);
+  } catch (e) {
+    dataError = e;
+  }
 
   const ctx = {
     route,
     pathname: url.pathname,
     user,
-    lobby: null,
-    error: null,
-    play: null,
-    submit: { existingCategories: [] },
-    moderate: { pending: null, forbidden: false },
-    admin: { elevated: null, currentHandle: null, forbidden: false },
+    lobby: fetched.lobby,
+    error: dataError ? String(dataError?.message || dataError) : null,
+    play: fetched.play,
+    submit: {
+      existingCategories: route === "submit" ? uniqueCategories(fetched.lobby) : [],
+    },
+    moderate: {
+      pending: fetched.modPending,
+      forbidden: route === "moderate" && !(user && user.isModerator),
+    },
+    admin: {
+      elevated: fetched.adminElevated,
+      currentHandle: user?.handle || null,
+      forbidden: route === "admin" && !(user && user.isAdmin),
+    },
   };
 
-  try {
-    if (route === "lobby" || route === "submit") {
-      const engine = createEngine({
-        puzzles: d1Puzzles(env.DB),
-        sessions: d1Sessions(env.DB),
-      });
-      ctx.lobby = await engine.listPuzzles();
-      if (route === "submit") {
-        ctx.submit.existingCategories = uniqueCategories(ctx.lobby);
-      }
-    }
-
-    if (route === "play") {
-      ctx.play = await resolvePlay(env, url.searchParams);
-    }
-
-    if (route === "moderate") {
-      if (!user || !user.isModerator) {
-        ctx.moderate.forbidden = true;
-      } else {
-        ctx.moderate.pending = await d1Submissions(env.DB).listPending();
-      }
-    }
-
-    if (route === "admin") {
-      ctx.admin.currentHandle = user?.handle || null;
-      if (!user || !user.isAdmin) {
-        ctx.admin.forbidden = true;
-      } else {
-        ctx.admin.elevated = await d1Users(env.DB).listByRoles(["moderator", "admin"]);
-      }
-    }
-  } catch (e) {
-    ctx.error = String(e?.message || e);
-  }
-
-  const assets = await loadAssets(env, url);
+  const assets = await assetsPromise;
   const html = renderPage(ctx, assets);
 
   return new Response(html, {
     status: route === "not-found" ? 404 : 200,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
-      "Cache-Control": "no-store",
+      /* `private` keeps shared caches (CDN, ISP) out so per-user
+         header content stays user-private; `no-cache` forces the
+         browser to revalidate before reuse; `must-revalidate`
+         disallows serving stale on revalidation failure. Unlike
+         `no-store`, this set still permits the back/forward cache,
+         which Lighthouse flagged as a perf regression on t4bs.com. */
+      "Cache-Control": "private, no-cache, must-revalidate",
       "X-T4BS-SSR": "bn",
     },
   });

--- a/src/bn/hydrate.test.js
+++ b/src/bn/hydrate.test.js
@@ -220,6 +220,20 @@ describe("renderPage — emits a complete BaseNative-rendered HTML document for 
     const json = JSON.parse(html.slice(start, end).split(">")[1]);
     assert.equal(json.route, "play");
   });
+
+  /* Lighthouse network-dependency-tree-insight flagged the hydrate
+     bundle as a late-discovered critical-path resource. The fix
+     emits a <link rel="modulepreload"> in the head so the browser
+     can start the fetch in parallel with stylesheet + font requests. */
+  it("preloads the hydrate bundle via <link rel=\"modulepreload\">", () => {
+    const assets = { js: "/assets/bn-hydrate-abc123.js", css: [] };
+    const html = renderPage(baseCtx(), assets);
+    assert.match(
+      html,
+      /<link[^>]*rel="modulepreload"[^>]*href="\/assets\/bn-hydrate-abc123\.js"/,
+      "expected a modulepreload link for the hydrate bundle in <head>",
+    );
+  });
 });
 
 describe("decidePlayBoot", () => {

--- a/src/bn/views/header.js
+++ b/src/bn/views/header.js
@@ -3,10 +3,17 @@
    keeps it portable across the @basenative/server SSR worker and
    any node:test consumers. */
 
+/* axe \`label-content-name-mismatch\`: where a control has visible
+   text, its accessible name must contain that text. The previous
+   aria-label values ("Tabs home", "Signed in as wmd") replaced
+   visible "T4BS" / handle entirely. The fixed shape uses visible
+   text + a <span class="sr-only"> suffix so the accessible name is
+   a superset of what the user sees. */
 export default `<header role="banner" data-bn-region="header">
   <nav aria-label="Tabs primary">
-    <a href="/" data-bn-action="logo" aria-label="Tabs home">
+    <a href="/" data-bn-action="logo">
       <strong>T<em>4</em>BS</strong>
+      <span class="sr-only"> — Tabs home</span>
     </a>
 
     <template @if="route === 'play' &amp;&amp; play">
@@ -27,8 +34,9 @@ export default `<header role="banner" data-bn-region="header">
       </li>
       <template @if="user">
         <li>
-          <button type="button" data-bn-action="account" :aria-label="'Signed in as ' + user.handle">
+          <button type="button" data-bn-action="account">
             {{ user.handle }}
+            <span class="sr-only"> — open account menu</span>
           </button>
         </li>
       </template>

--- a/src/bn/views/layout.js
+++ b/src/bn/views/layout.js
@@ -57,6 +57,13 @@ export default `<!DOCTYPE html>
       <link rel="stylesheet" :href="href" />
     </template>
 
+    <!-- The hydrate bundle is the longest critical-path JS request.
+         Discovered late by the browser (script tag is at end of body),
+         which Lighthouse flags as a network-dependency-tree depth
+         problem. modulepreload lets the browser start fetching as soon
+         as the head is parsed, parallel with stylesheet + font fetches. -->
+    <link rel="modulepreload" :href="jsAsset" />
+
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/src/bn/views/lobby.js
+++ b/src/bn/views/lobby.js
@@ -49,7 +49,7 @@ export default `<main aria-labelledby="lobby-title" data-bn-view="lobby">
   </section>
 
   <a href="/submit" data-bn-action="lobby-submit" aria-label="Submit a phrase">
-    + Submit a phrase
+    <span aria-hidden="true">+ </span>Submit a phrase
   </a>
 </main>
 `;

--- a/src/bn/views/submit.js
+++ b/src/bn/views/submit.js
@@ -52,7 +52,7 @@ export default `<main aria-labelledby="submit-title" data-bn-view="submit">
       <p role="alert" data-bn-bind="submit-error" hidden></p>
     </fieldset>
 
-    <button type="submit" data-bn-action="submit-confirm" aria-label="Submit for review">
+    <button type="submit" data-bn-action="submit-confirm">
       Submit for review
     </button>
     <button type="button" data-bn-action="submit-cancel">Cancel</button>

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -17,17 +17,22 @@ export function createHeader({
   onAdmin,
   onLogout,
 }) {
+  /* axe `label-content-name-mismatch` — when a control has visible
+     text, its accessible name must contain that text. The old
+     aria-label="Back to lobby" overrode the visible "T4BS" entirely
+     (Lighthouse a11y regression). Now the accessible name is
+     "T4BS — back to lobby" via visible text + sr-only suffix. */
   const logo = h("button", {
     class: "lb-logo",
     type: "button",
     onClick: onLogo,
-    "aria-label": "Back to lobby",
   },
     h("span", { class: "lb-logo-box", "aria-hidden": "true" },
       // Mini Tabs mark — T + accent dot
       svgMark(),
     ),
-    "T4BS"
+    "T4BS",
+    h("span", { class: "sr-only" }, " — back to lobby"),
   );
 
   const right = h("div", { class: "lb-hd-r" });

--- a/src/views/lobby.js
+++ b/src/views/lobby.js
@@ -59,16 +59,20 @@ export function createLobby({
       const credit = group.puzzles.length === 1
         ? `by ${group.puzzles[0].submittedBy}`
         : `${group.puzzles.length} puzzles`;
+      /* axe `label-content-name-mismatch`: previously aria-label
+         overrode the visible category + credit text. Now the
+         accessible name is built from the visible text plus a
+         sr-only "Play " prefix, so it matches what the user sees. */
       return h("li", null,
         h("button", {
           type: "button",
           class: "lb-lobby-item",
-          "aria-label": `Play ${group.category} — ${credit}`,
           onClick: () => {
             const pick = group.puzzles[Math.floor(Math.random() * group.puzzles.length)];
             onPick(pick.id);
           },
         },
+          h("span", { class: "sr-only" }, "Play "),
           h("span", { class: "lb-lobby-cat" }, group.category),
           h("span", { class: "lb-lobby-by" }, credit),
         ),


### PR DESCRIPTION
Refs #10. Doesn't close the issue — bootup-time and render-blocking CSS still need a code-split pass that's larger than this.

## Lighthouse baseline (https://t4bs.com today)

| Category | Score | Notable failing audits |
| --- | --- | --- |
| Performance | 53 | TBT 2,830ms, LCP 4.4s, server-response-time 1,280ms, render-blocking CSS, late JS discovery, bf-cache disabled |
| Accessibility | 100 | (overall pass) but `label-content-name-mismatch` reported on 11 buttons |
| Best practices | 82 | All 3 deprecation warnings come from `cdn-cgi/challenge-platform/scripts/jsd/main.js` (Cloudflare bot-management infra — not actionable here) |
| SEO | 100 | — |

## Fixes in this PR

### a11y — `label-content-name-mismatch`

The axe rule says: when a control has visible text, its accessible name must contain that text. The previous `aria-label` values replaced the visible text entirely:

- Header logo: `aria-label="Back to lobby"` over visible `T4BS` → mismatch.
- Lobby buttons: `aria-label="Play CATEGORY — by AUTHOR"` over visible `CATEGORY` + `by AUTHOR` → mismatch.
- Header account button: `aria-label="Signed in as wmd"` over visible `wmd` → mismatch.
- "+ Submit a phrase" FAB: `aria-label="Submit a phrase"` over visible `+ Submit a phrase` → mismatch (the `+` prefix).

Fix: drop the overriding `aria-label` and add a `<span class="sr-only">` prefix/suffix so the accessible name is a superset of the visible text. Decorative `+` is wrapped in `<span aria-hidden="true">`. Applied to both the SPA imperative views (`src/components/header.js`, `src/views/lobby.js`) and the SSR templates (`src/bn/views/header.js`, `src/bn/views/lobby.js`, `src/bn/views/submit.js`).

### perf — parallel SSR data fetches

`functions/_shared/ssr.js` was sequential: user → route data → asset manifest. Now all three lanes start together; lanes that depend on the user (moderate `listPending`, admin `listByRoles`) await `userPromise` inside their lane. Same ordering invariant, fewer round-trips on the critical path.

### perf — enable bf-cache

Lighthouse flagged the SSR root document as bf-cache-ineligible because of `Cache-Control: no-store`. We don't need `no-store` — content is private to the requesting user (WebAuthn cookie scope), not a secret-on-shared-machine risk. Switched to:

```
Cache-Control: private, no-cache, must-revalidate
```

Shared caches still skip; browsers must revalidate before reuse; bf-cache is now eligible. `/api/*` responses keep `no-store` via the middleware `decorate()` override.

### perf — `<link rel="modulepreload">` for the hydrate bundle

`bn-hydrate.js` is the longest critical-path JS, but its `<script type="module">` lives at end-of-body — the browser doesn't discover it until the document is parsed. Added a `<link rel="modulepreload" :href="jsAsset">` in `layout.js` head so the fetch starts in parallel with stylesheet + font requests. Locked in by a new test in `src/bn/hydrate.test.js`.

## What's intentionally NOT in this PR

- **Render-blocking CSS** (`assets/admin-*.css`, ~6.4 KB, 215ms savings). Async-loading via `media="print" onload="this.media='all'"` would risk FOUC on the lobby. Real fix is critical-CSS extraction; out of scope for a quick-wins pass.
- **TBT 2,830ms / bootup-time 5.8s**. Comes from the shared chunk being eagerly imported (statically references admin/moderate/submit views). Lazy-importing the elevated-only views via `import()` would split that chunk and cut initial JS by ~50KB. Significant refactor; tracking separately.
- **server-response-time 1,280ms**. After Promise.all, the remaining cost is mostly D1 latency + isolate cold start; not addressable in code without a caching layer that varies by user.
- **3 deprecation warnings** — all from `cdn-cgi/challenge-platform` (Cloudflare bot-management); not our code.

## Verification

- `node --test src/bn/hydrate.test.js` — 22/22 (one new test for modulepreload).
- `node --test shared/engine.test.js` — 54/54.
- `npm run lint`, `typecheck`, `build` all clean.
- Live preview confirms: `Cache-Control: private, no-cache, must-revalidate` on `/`, `/play`, `/admin`, `/moderate`; modulepreload link in `<head>`; no `aria-label="Play X"` / `"Tabs home"` / `"Signed in as"` survive in the SSR output.

## Test plan

- [ ] Re-run Lighthouse against the deploy preview — expect a11y still 100 with `label-content-name-mismatch` resolved, perf bumps from bf-cache + modulepreload + parallel fetches.
- [ ] Hit `/`, `/play`, `/moderate`, `/admin`, `/wat` — all SSR'd routes still respond with the right content shape and `X-T4BS-SSR: bn` header.
- [ ] Browser back/forward navigation across `/` ↔ `/play` should restore from bf-cache (instant, no network) instead of re-fetching.
- [ ] Screen reader smoke: confirm "T4BS, button — back to lobby" / "Play BEATLES SONGS, button — by house" announcement on Mac VoiceOver / NVDA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)