### PR TITLE
fix(security): unbiased share-card ids + drop weak session-id fallback

### DIFF
--- a/functions/api/share-cards.js
+++ b/functions/api/share-cards.js
@@ -13,11 +13,27 @@ import { d1ShareCards } from "../_shared/d1.js";
 const ID_ALPHABET = "23456789abcdefghjkmnpqrstuvwxyz"; // unambiguous
 const ID_LEN = 8;
 
+/* Generate an unbiased ID from a 31-char alphabet using rejection
+   sampling. Naive `byte % 31` biases the first 8 chars upward by ~3.1%
+   each because 256 isn't a multiple of 31; the upper [248..255] range
+   maps onto chars 0..7 a second time. We discard those bytes and pull
+   more from `crypto.getRandomValues` until we have ID_LEN unbiased
+   draws. The over-allocation by 4 bytes amortizes the rare reloop. */
 function shortId() {
-  const bytes = crypto.getRandomValues(new Uint8Array(ID_LEN));
-  let out = "";
-  for (let i = 0; i < ID_LEN; i++) out += ID_ALPHABET[bytes[i] % ID_ALPHABET.length];
-  return out;
+  const A = ID_ALPHABET.length;       // 31
+  const REJECT = 256 - (256 % A);     // 248 — bytes >= REJECT are in the biased tail
+  const out = new Array(ID_LEN);
+  let filled = 0;
+  while (filled < ID_LEN) {
+    const buf = new Uint8Array(ID_LEN - filled + 4);
+    crypto.getRandomValues(buf);
+    for (let i = 0; i < buf.length && filled < ID_LEN; i++) {
+      const b = buf[i];
+      if (b >= REJECT) continue;
+      out[filled++] = ID_ALPHABET[b % A];
+    }
+  }
+  return out.join("");
 }
 
 export const onRequestPost = async ({ request, env }) => {

--- a/shared/engine.js
+++ b/shared/engine.js
@@ -3,9 +3,17 @@
 
 import { evalWord, scoreGuess, openSlots, publicShape, initialState } from "./pure.js";
 
+/* Session IDs are an authentication token in everything but name —
+   anyone holding one can call /api/guess and progress that round. They
+   need to be from a CSPRNG. crypto.randomUUID is available in every
+   runtime t4bs targets (Cloudflare Workers, Node ≥18, modern browsers
+   for the Vite dev mock); the previous Math.random() fallback was
+   dead code that CodeQL still flagged because the lexical reachability
+   analysis can't prove that. Drop the fallback so the analyser stops
+   tripping and so a hypothetical future runtime without crypto fails
+   loudly instead of silently issuing weak IDs. */
 function newId() {
-  if (typeof crypto !== "undefined" && crypto.randomUUID) return crypto.randomUUID();
-  return Array.from({length:32}, () => Math.floor(Math.random()*16).toString(16)).join("");
+  return crypto.randomUUID();
 }
 
 export function createEngine({ puzzles, sessions }) {


### PR DESCRIPTION
Resolves two CodeQL high-severity findings on the worker code path.

## 1. `functions/api/share-cards.js` — biased random from a CSPRNG source

`shortId()` indexed a 31-char alphabet with `byte % 31` over uniformly random bytes 0..255. Bytes 248..255 wrap onto alphabet positions 0..7 a second time, so digits 2-9 appeared **~3.1% more often** than letters a-z. CodeQL flag: *"Creating biased random numbers from a cryptographically secure source."* In practice this shrinks the effective ID space and narrows brute-force search.

**Fix: rejection sampling.** Discard bytes >= 248 (the biased tail) and draw more from `crypto.getRandomValues` until `ID_LEN` unbiased draws land. Over-allocate by 4 bytes per refill so the rare miss (~3.1% per byte) almost never reloops.

Empirically verified — 100k IDs (800k character samples):

| Implementation | Max deviation across alphabet |
| --- | --- |
| Old `byte % 31` | ~3.1% (deterministic, on chars 0–7) |
| New rejection sample | 1.04% (well within noise for n=800k) |

## 2. `shared/engine.js` — `Math.random()` fallback for session IDs

`newId()` preferred `crypto.randomUUID()` but fell back to `Math.random` for environments without crypto. Session IDs are an authentication token in everything but name (anyone holding one can POST `/api/guess` against that round), so the fallback is a real finding even if it never actually executes in production.

Every runtime t4bs targets has `crypto.randomUUID`:
- Cloudflare Workers (since 2022)
- Node ≥18
- Modern browsers (Vite dev mock only)

**Fix: drop the fallback.** If a hypothetical future runtime lacks `crypto.randomUUID`, fail loudly at the implicit `crypto is undefined` throw rather than silently issue weak IDs.

## Other `Math.random()` sites — intentionally untouched

| File | Use | Action |
| --- | --- | --- |
| `src/lib/confetti.js` | Visual confetti spread | Leave — not security-relevant; CodeQL didn't flag it |
| `src/views/lobby.js:68` | Random puzzle within a category | Leave — not security-relevant; gameplay-only |

## Verification

- `node --test shared/engine.test.js` — 54/54.
- `node --test src/bn/hydrate.test.js` — 21/21.
- `npm run lint`, `typecheck`, `build` — all clean.
- Live worker round-trip:
  - `POST /api/session` returns a real RFC-4122 UUID v4 (`584e5716-8a22-4524-8177-e21eb910e577`).
  - Two consecutive `POST /api/share-cards` calls return distinct 8-char IDs matching `/^[23456789abcdefghjkmnpqrstuvwxyz]{8}$/` with `t4bs.com/s/<id>` URLs.

## Test plan

- [ ] Re-run CodeQL on the merge — both alerts should clear.
- [ ] Spot-check existing `share_cards` rows in D1 stay valid (no schema change; the column still stores arbitrary 8-char strings, the change is only the *generator's* distribution).
- [ ] Confirm `gh api repos/DuganLabs/t4bs/code-scanning/alerts` shows the two alerts as `dismissed` or `fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)