### PR TITLE
views: rewrite SPA in semantic HTML matching SSR (PB-style)

### DIFF
--- a/src/_shims/bn-runtime-expression.js
+++ b/src/_shims/bn-runtime-expression.js
@@ -1,0 +1,24 @@
+/* Stub for @basenative/runtime@0.4.0's broken sibling import.
+
+   The published tarball's evaluate.js and scope.js reference
+   '../../../src/shared/expression.js' — a monorepo-relative path that
+   doesn't exist in node_modules after install. Vite/rolldown can't
+   resolve it and the dev server / build refuse to start.
+
+   t4bs's SPA only uses signal/computed/effect/batch from the runtime
+   (no template-string hydration), so the unused expression evaluator
+   can be stubbed. Scope.js does use the SCOPE_SLOT symbol — provide a
+   real one. evaluateExpression is fenced behind code paths we never
+   reach; throwing on call surfaces any accidental use immediately.
+
+   PendingBusiness solved this by writing their own signals.js shim
+   (apps/site/src/signals.ts). When @basenative/runtime ships a fixed
+   tarball this file goes away with the alias in vite.config.js. */
+
+export const SCOPE_SLOT = Symbol("SCOPE_SLOT");
+
+export function evaluateExpression() {
+  throw new Error(
+    "evaluateExpression() not implemented — t4bs SPA does not use the @basenative/runtime expression evaluator.",
+  );
+}

--- a/src/lib/bind.js
+++ b/src/lib/bind.js
@@ -1,0 +1,96 @@
+/* BaseNative-flavored signal-to-DOM binding helpers.
+   Same shape as PendingBusiness's lib/bind.ts: attach effects to existing
+   DOM nodes by id or element ref so views can be expressed as
+   "signals in, DOM mutations out" without juggling `effect` + manual
+   property assignments at every call site.
+
+   These complement the imperative `h()` builder in dom.js: the builder
+   composes the semantic structure once, and these helpers keep it in
+   sync with signals after mount. */
+
+import { effect } from "@basenative/runtime";
+
+/** @typedef {{ (): unknown } | { (): unknown, set: (v: unknown) => void, peek: () => unknown }} Signal */
+/** @template T @typedef {(() => T) | { (): T }} Readable */
+
+function read(source) {
+  return source();
+}
+
+function resolve(idOrEl) {
+  if (idOrEl == null) return null;
+  if (typeof idOrEl !== "string") return idOrEl;
+  return document.getElementById(idOrEl);
+}
+
+/** Bind a signal/computed to an element's textContent. */
+export function bindText(idOrEl, source) {
+  const el = resolve(idOrEl);
+  if (!el) return;
+  effect(() => { el.textContent = String(read(source) ?? ""); });
+}
+
+/** Bind a signal/computed to an attribute. null/undefined → removeAttribute. */
+export function bindAttr(idOrEl, attr, source) {
+  const el = resolve(idOrEl);
+  if (!el) return;
+  effect(() => {
+    const v = read(source);
+    if (v == null || v === false) el.removeAttribute(attr);
+    else el.setAttribute(attr, v === true ? "" : String(v));
+  });
+}
+
+/** Toggle a class based on a boolean signal. */
+export function bindClass(idOrEl, className, source) {
+  const el = resolve(idOrEl);
+  if (!el) return;
+  effect(() => { el.classList.toggle(className, !!read(source)); });
+}
+
+/** Bind the full className string. */
+export function bindClassName(idOrEl, source) {
+  const el = resolve(idOrEl);
+  if (!el) return;
+  effect(() => { el.className = String(read(source) ?? ""); });
+}
+
+/* Toggle visibility. Sets both the `hidden` attribute (for assistive
+   tech + the no-JS HTML semantic) AND an `is-hidden` class (which
+   carries `display: none !important` in styles.css — needed to win
+   against rules like `.lb-stats { display: flex }` that would otherwise
+   defeat the UA `[hidden]` style). */
+export function bindHidden(idOrEl, source) {
+  const el = resolve(idOrEl);
+  if (!el) return;
+  effect(() => {
+    const off = !!read(source);
+    el.classList.toggle("is-hidden", off);
+    if (off) el.setAttribute("hidden", "");
+    else el.removeAttribute("hidden");
+  });
+}
+
+/** Mirror a boolean signal to a form control's `disabled`. */
+export function bindDisabled(idOrEl, source) {
+  const el = resolve(idOrEl);
+  if (!el) return;
+  effect(() => { el.disabled = !!read(source); });
+}
+
+/**
+ * Render a list signal into a container's children. Bulk replaceChildren
+ * on every change — same approach as PB's bindList.
+ */
+export function bindList(idOrEl, source, render, empty) {
+  const el = resolve(idOrEl);
+  if (!el) return;
+  effect(() => {
+    const items = read(source);
+    if (!items || items.length === 0) {
+      el.replaceChildren(empty ? empty() : document.createComment("empty"));
+      return;
+    }
+    el.replaceChildren(...items.map((item, i) => render(item, i)));
+  });
+}

--- a/src/views/lobby.js
+++ b/src/views/lobby.js
@@ -1,108 +1,117 @@
-/* Single-file component: LOBBY view.
-   Pulls /api/puzzles, groups by category, lets the player tap into a round.
-   Shows personal stats from @basenative/persist (formerly src/lib/persist.js). */
+/* LOBBY view — semantic mirror of src/bn/views/lobby.js (SSR).
 
-import { computed, effect } from "@basenative/runtime";
-import { h, reactiveList } from "../lib/dom.js";
+   <main data-bn-view="lobby"> with <header>, <section data-bn-region="stats">,
+   <section data-bn-region="list">, and a "submit" CTA. The shape matches the
+   SSR template so crawlers and the SPA produce the same DOM. */
+
+import { computed } from "@basenative/runtime";
+import { h } from "../lib/dom.js";
+import { bindHidden, bindList, bindText } from "../lib/bind.js";
 import { groupLobby } from "../lib/game.js";
 
 export function createLobby({
-  lobby,        // signal<array | null>
-  stats,        // signal<object>
-  error,        // signal<string | null>
-  user,         // signal<object | null>
-  onPick,       // (puzzleId) => void
-  onSubmit,     // () => void  (opens submit view or auth modal)
+  lobby,
+  stats,
+  error,
+  user,
+  onPick,
+  onSubmit,
 }) {
+  void user; // accepted for parity with hydrate.js wiring; unused right now
+
   const groups = computed(() => groupLobby(lobby()));
+  const hasStats = computed(() => (stats()?.played || 0) > 0);
 
-  const errorRow = h("div", {
-    class: "lb-cred lb-cred-error",
-    role: "alert",
-    text: () => `error: ${error() || ""}`,
-    hidden: () => !error(),
-  });
+  /* Stats — three little chips, only visible after the first played round. */
+  const winsB    = h("strong");
+  const bestB    = h("strong");
+  const streakB  = h("strong");
+  bindText(winsB,   () => String(stats()?.wins || 0));
+  bindText(bestB,   () => String(stats()?.best || 0));
+  bindText(streakB, () => (stats()?.streak || 0) > 0 ? `🔥${stats().streak}` : "—");
 
-  const statsRow = h("div", {
+  const statsSection = h("section", {
     class: "lb-stats",
     "aria-label": "Personal stats",
-    hidden: () => !(stats()?.played > 0),
+    "data-bn-region": "stats",
+  },
+    h("p", { class: "lb-stat" }, winsB,   h("small", null, "WINS")),
+    h("p", { class: "lb-stat" }, bestB,   h("small", null, "BEST")),
+    h("p", { class: "lb-stat" }, streakB, h("small", null, "STREAK")),
+  );
+  bindHidden(statsSection, () => !hasStats());
+
+  /* Error — single status paragraph, hidden by default. */
+  const errorEl = h("p", {
+    class: "lb-cred lb-cred-error",
+    role: "alert",
+    "data-bn-region": "error",
   });
-  effect(() => {
-    const s = stats() || {};
-    statsRow.replaceChildren(
-      h("span", { class: "lb-stat" },
-        h("b", { text: () => String(s.wins || 0) }),
-        h("span", null, "WINS"),
-      ),
-      h("span", { class: "lb-stat" },
-        h("b", { text: () => String(s.best || 0) }),
-        h("span", null, "BEST"),
-      ),
-      h("span", { class: "lb-stat" },
-        h("b", { text: () => s.streak > 0 ? `🔥${s.streak}` : "—" }),
-        h("span", null, "STREAK"),
+  bindText(errorEl, () => `error: ${error() || ""}`);
+  bindHidden(errorEl, () => !error());
+
+  /* Puzzle list — bindList over groups. */
+  const list = h("ul", {
+    class: "lb-lobby",
+    role: "list",
+    "aria-label": "Available puzzles",
+    "data-bn-region": "list",
+  });
+  bindList(list, groups, (group) => {
+    const credit = group.puzzles.length === 1
+      ? `by ${group.puzzles[0].submittedBy}`
+      : `${group.puzzles.length} puzzles`;
+    return h("li", null,
+      h("button", {
+        type: "button",
+        class: "lb-lobby-item",
+        "data-bn-action": "lobby-pick",
+        "data-puzzle-ids": group.puzzles.map(p => p.id).join(","),
+        onClick: () => {
+          const pick = group.puzzles[Math.floor(Math.random() * group.puzzles.length)];
+          onPick(pick.id);
+        },
+      },
+        h("span", { class: "sr-only" }, "Play "),
+        h("strong", { class: "lb-lobby-cat" }, group.category),
+        h("small", { class: "lb-lobby-by" }, credit),
       ),
     );
-  });
-
-  const list = h("ul", { class: "lb-lobby", "aria-label": "Available puzzles" });
-  reactiveList(list, () => {
-    const g = groups();
-    if (!g) {
-      // Skeleton — six placeholder rows
-      return Array.from({ length: 6 }).map(() =>
-        h("li", null, h("div", { class: "lb-lobby-skel", "aria-hidden": "true" }))
-      );
+  }, () => {
+    /* Skeleton — six placeholder rows while /api/puzzles is in flight. */
+    const frag = document.createDocumentFragment();
+    for (let i = 0; i < 6; i++) {
+      frag.append(h("li", null, h("div", { class: "lb-lobby-skel", "aria-hidden": "true" })));
     }
-    return g.map(group => {
-      const credit = group.puzzles.length === 1
-        ? `by ${group.puzzles[0].submittedBy}`
-        : `${group.puzzles.length} puzzles`;
-      /* axe `label-content-name-mismatch`: previously aria-label
-         overrode the visible category + credit text. Now the
-         accessible name is built from the visible text plus a
-         sr-only "Play " prefix, so it matches what the user sees. */
-      return h("li", null,
-        h("button", {
-          type: "button",
-          class: "lb-lobby-item",
-          onClick: () => {
-            const pick = group.puzzles[Math.floor(Math.random() * group.puzzles.length)];
-            onPick(pick.id);
-          },
-        },
-          h("span", { class: "sr-only" }, "Play "),
-          h("span", { class: "lb-lobby-cat" }, group.category),
-          h("span", { class: "lb-lobby-by" }, credit),
-        ),
-      );
-    });
+    return frag;
   });
 
+  /* Floating "submit a phrase" CTA. */
   const fab = h("button", {
     class: "lb-fab",
     type: "button",
+    "data-bn-action": "lobby-submit",
     "aria-label": "Submit a phrase",
     onClick: onSubmit,
   }, "+ SUBMIT A PHRASE");
 
-  // Surface user state to suppress unused-var warnings; FAB handler reads
-  // current user via the consumer's onSubmit; we accept the signal for
-  // future reactivity (e.g. a "sign in to submit" hint).
-  void user;
-
-  return h("main", { "aria-labelledby": "lb-page-title" },
-    h("h1", { id: "lb-page-title", class: "sr-only" }, "T4BS — pick a round"),
-    h("div", { class: "lb-sticky lb-sticky-narrow" },
-      "One subject. One phrase.",
-      h("br"),
-      "No mercy."
+  return h("main", {
+    "aria-labelledby": "lobby-title",
+    "data-bn-view": "lobby",
+  },
+    h("header", null,
+      h("h1", { id: "lobby-title", class: "sr-only" }, "Tabs — pick a round"),
+      h("p", { class: "lb-sticky lb-sticky-narrow" },
+        "One subject. One phrase.", h("br"), "No mercy.",
+      ),
+      h("p", { class: "lb-tagline" }, "Pick a round"),
     ),
-    h("div", { class: "lb-tagline" }, "Pick a round"),
-    statsRow,
-    errorRow,
-    list,
+    statsSection,
+    errorEl,
+    h("section", { "aria-labelledby": "lobby-list-title" },
+      h("h2", { id: "lobby-list-title", class: "sr-only" }, "Available puzzles"),
+      list,
+    ),
     fab,
   );
 }

--- a/src/views/moderate.js
+++ b/src/views/moderate.js
@@ -1,10 +1,15 @@
-/* MODERATE view. Lists /api/moderate/pending submissions; approve / reject
-   in place. Uses @basenative/admin's shared queue renderer so the markup
-   matches the SSR first paint (and PendingBusiness once it migrates). */
+/* MODERATE view — semantic mirror of src/bn/views/moderate.js (SSR).
+
+   <main data-bn-view="moderate"> with <header>, <section data-bn-region="queue">,
+   and a back-to-lobby button. The queue list itself is rendered by
+   @basenative/admin's renderAdminQueueList (shared across BaseNative
+   admin surfaces), so its inner markup is owned by that package; this
+   file only wires the outer shell + click delegation. */
 
 import { signal, effect } from "@basenative/runtime";
 import { renderAdminQueueList } from "@basenative/admin/components";
 import { h } from "../lib/dom.js";
+import { bindHidden, bindText } from "../lib/bind.js";
 import { api } from "../lib/api.js";
 
 export function createModerate({ toaster, onLobbyChange, goLobby }) {
@@ -28,14 +33,23 @@ export function createModerate({ toaster, onLobbyChange, goLobby }) {
     }
   }
 
-  const errBox = h("div", { class: "lb-ferror", text: () => err() || "", hidden: () => !err() });
+  const errBox = h("p", { class: "lb-ferror", role: "alert", "data-bn-region": "error" });
+  bindText(errBox, () => err() || "");
+  bindHidden(errBox, () => !err());
 
-  const queueRoot = h("div");
+  const queueRoot = h("section", {
+    class: "bn-admin-queue-host",
+    "aria-label": "Pending submissions",
+    "data-bn-region": "queue",
+    "data-bn-bind": "moderate-list",
+  });
   effect(() => {
+    if (err()) { queueRoot.replaceChildren(); return; }
     const items = list();
-    if (err()) { queueRoot.innerHTML = ""; return; }
     if (items === null) {
-      queueRoot.innerHTML = `<div class="lb-cred">loading…</div>`;
+      queueRoot.replaceChildren(
+        h("p", { class: "lb-cred", role: "status", "aria-live": "polite" }, "loading…"),
+      );
       return;
     }
     queueRoot.innerHTML = renderAdminQueueList({ items, actionHandler: "mod-decide" });
@@ -47,12 +61,22 @@ export function createModerate({ toaster, onLobbyChange, goLobby }) {
     decide(Number(btn.dataset.id), btn.dataset.decision);
   });
 
-  return h("main", { "aria-labelledby": "lb-mod-title" },
-    h("h1", { id: "lb-mod-title", class: "sr-only" }, "Moderation queue"),
-    h("div", { class: "lb-sticky lb-sticky-narrow" }, "Moderation queue"),
-    h("div", { class: "lb-tagline" }, "Approve or reject pending phrases"),
+  return h("main", {
+    "aria-labelledby": "moderate-title",
+    "data-bn-view": "moderate",
+  },
+    h("header", null,
+      h("h1", { id: "moderate-title", class: "sr-only" }, "Moderation queue"),
+      h("p", { class: "lb-sticky lb-sticky-narrow" }, "Moderation queue"),
+      h("p", { class: "lb-tagline" }, "Approve or reject pending phrases"),
+    ),
     errBox,
     queueRoot,
-    h("button", { class: "lb-btn lb-bs lb-bs-back", type: "button", onClick: goLobby }, "← Back"),
+    h("button", {
+      type: "button",
+      class: "lb-btn lb-bs lb-bs-back",
+      "data-bn-action": "back",
+      onClick: goLobby,
+    }, "← Back"),
   );
 }

--- a/src/views/play.js
+++ b/src/views/play.js
@@ -1,48 +1,53 @@
-/* Single-file component: PLAY view.
-   All game state is signal-driven. Calls into shared/engine.js indirectly via
-   /api endpoints. The on-screen keyboard is @basenative/keyboard. */
+/* PLAY view — semantic, signal-driven mirror of src/bn/views/play.js (SSR).
+
+   Same shape the SSR template produces (<main data-bn-view="play"> with
+   <header data-bn-region="play-summary">, <section data-bn-region="grid">,
+   <section data-bn-region="bank">, <section data-bn-region="keyboard">,
+   <dialog data-bn-region="end-overlay">). The bind helpers in lib/bind.js
+   wire signals into the existing nodes — no class-soup div builders, no
+   imperative children-replace except for the phrase grid and letter bank
+   where the cell count is inherently dynamic. */
 
 import { signal, computed, effect } from "@basenative/runtime";
 import { Keyboard } from "@basenative/keyboard";
-import { h, reactiveList } from "../lib/dom.js";
+import { h } from "../lib/dom.js";
+import { bindAttr, bindClassName, bindHidden, bindText } from "../lib/bind.js";
 import { api } from "../lib/api.js";
 import { openSlots, fullCount, computeKeyStatus } from "../lib/game.js";
 import { confetti } from "../lib/confetti.js";
 
 export function createPlay({
-  session,        // signal<object>      — initial public shape from /api/session
-  locked,         // signal<array<map>>  — wi -> { li -> letter }
-  presentGlobal,  // signal<string[]>
-  absentByWord,   // signal<string[][]>
-  wordSolved,     // signal<boolean[]>
-  posFeedback,    // signal<(green|yellow|absent|null)[][]>
-  score,          // signal<number>
-  lives,          // signal<number>
-  tokens,         // signal<number>
-  phase,          // signal<'playing'|'won'|'lost'>
-  reveal,         // signal<string[] | null>
-  toaster,        // (text, type) => void
-  onResultRecorded, // (won, score, category) => void
-  onShare,        // ({ won }) => Promise<string>  — returns label
+  session,
+  locked,
+  presentGlobal,
+  absentByWord,
+  wordSolved,
+  posFeedback,
+  score,
+  lives,
+  tokens,
+  phase,
+  reveal,
+  toaster,
+  onResultRecorded,
+  onShare,
   goLobby,
-  retry,          // () => void  — restart the same puzzle
+  retry,
 }) {
-  // ── per-render UI signals ──────────────────────────────────────────────
-  const active    = signal(null);
-  const typed     = signal(session.peek().words.map(() => []));
-  const wagers    = signal(session.peek().words.map(() => []));
-  const allInMode = signal(false);
-  const casc      = signal(false);
-  const feedback  = signal({});       // wi -> [{idx, letter, status}]
-  const shaking   = signal(null);
-  const cascDrop  = signal(null);
-  const shareLbl  = signal(null);
+  /* ── per-round UI signals ──────────────────────────────────────────── */
+  const active     = signal(null);
+  const typed      = signal(session.peek().words.map(() => []));
+  const wagers     = signal(session.peek().words.map(() => []));
+  const allInMode  = signal(false);
+  const casc       = signal(false);
+  const feedback   = signal({});       // wi -> [{idx, letter, status}]
+  const shaking    = signal(null);
+  const cascDrop   = signal(null);
+  const shareLbl   = signal(null);
+  const announcement = signal("");
   let resultRecorded = false;
 
-  // ── accessibility announcements ────────────────────────────────────────
-  const announcement = signal("");
-
-  // ── derived ────────────────────────────────────────────────────────────
+  /* ── derived ───────────────────────────────────────────────────────── */
   const keyStatus = computed(() => computeKeyStatus({
     session: session(),
     locked: locked(),
@@ -61,9 +66,24 @@ export function createPlay({
     return `Type ${room} more letter${room === 1 ? "" : "s"} for word ${active() + 1}.`;
   });
 
+  const cbarText = computed(() => {
+    if (casc()) return "⚡ Earned reveal — pick any tile in any unsolved word";
+    if (allInMode()) return `ALL IN — type the rest of the phrase · SHOVE to commit · +${allInBonus()} pts if right · 0 lives if wrong`;
+    return "";
+  });
+
   const allInBonus = computed(() => fullCount(session().words, locked()) * 8);
 
-  // ── auto-pick the first unsolved word when phase changes / a word solves ──
+  const stakeText = computed(() => {
+    const wagerCount = allInMode()
+      ? wagers().reduce((acc, w) => acc + (w?.length || 0), 0)
+      : (active() !== null ? (wagers()[active()]?.length || 0) : 0);
+    if (wagerCount > 0) return `${wagerCount}× STAKED`;
+    if (allInMode()) return "TYPE THE REST";
+    return "";
+  });
+
+  /* ── effects: word focus + result recording ───────────────────────── */
   effect(() => {
     if (phase() !== "playing" || casc()) return;
     const ws = wordSolved();
@@ -74,7 +94,6 @@ export function createPlay({
     }
   });
 
-  // ── record result + confetti when round ends ──
   effect(() => {
     const p = phase();
     if (resultRecorded) return;
@@ -91,7 +110,7 @@ export function createPlay({
     }
   });
 
-  // ── typing primitives ──────────────────────────────────────────────────
+  /* ── typing primitives ─────────────────────────────────────────────── */
   const findGlobalNextSlot = () => {
     const s = session();
     if (!s) return null;
@@ -155,7 +174,7 @@ export function createPlay({
     }));
   };
 
-  // ── submit one word ────────────────────────────────────────────────────
+  /* ── submit one word ──────────────────────────────────────────────── */
   async function submit(wi) {
     if (phase() !== "playing" || casc() || wordSolved()[wi]) return;
     const s = session();
@@ -197,11 +216,8 @@ export function createPlay({
       if (won) {
         wordSolved.set(prev => prev.map((v, i) => i !== wi ? v : true));
         active.set(null);
-        const wagerCount = wagers().length > 0 ? 0 : 0; // wagers reset above
-        const wagerNote = wagerCount > 0 ? ` · ${wagerCount}× STAKE WON` : "";
-        const msg = `Correct! Word ${wi + 1} solved. ${result.lives} lives remaining.`;
-        announcement.set(msg);
-        toaster(`+${result.scoreDelta}pts${wagerNote}`, "great");
+        announcement.set(`Correct! Word ${wi + 1} solved. ${result.lives} lives remaining.`);
+        toaster(`+${result.scoreDelta}pts`, "great");
         if (result.cascadeEarned) {
           setTimeout(() => {
             casc.set(true);
@@ -210,8 +226,7 @@ export function createPlay({
         }
       } else {
         shaking.set(wi); setTimeout(() => shaking.set(null), 480);
-        const msg = `Incorrect. ${result.lives} lives remaining.`;
-        announcement.set(msg);
+        announcement.set(`Incorrect. ${result.lives} lives remaining.`);
         toaster(`${result.scoreDelta}pts`, "bad");
       }
       setTimeout(() => {
@@ -226,7 +241,6 @@ export function createPlay({
     }
   }
 
-  // ── cascade pick ────
   async function pickCascade(wi, li) {
     if (!casc() || tokens() <= 0 || wordSolved()[wi]) return;
     if (locked()[wi][li] !== undefined) return;
@@ -246,7 +260,6 @@ export function createPlay({
     }
   }
 
-  // ── all-in ────
   function openAllIn() {
     if (allInMode()) {
       allInMode.set(false);
@@ -259,6 +272,7 @@ export function createPlay({
     allInMode.set(true);
     announcement.set("All-in mode. Type the rest of the phrase to shove.");
   }
+
   async function submitAllIn() {
     const s = session();
     if (!s || !allInMode()) return;
@@ -310,7 +324,7 @@ export function createPlay({
     }
   }
 
-  // ── physical keyboard ──
+  /* ── physical keyboard ────────────────────────────────────────────── */
   effect(() => {
     if (phase() !== "playing" || casc() || (active() === null && !allInMode())) return;
     const onKey = (e) => {
@@ -325,60 +339,110 @@ export function createPlay({
     return () => document.removeEventListener("keydown", onKey);
   });
 
-  // ── Accessibility: visually-hidden announcement region ──
-  const ariaLive = h("div", {
+  /* ── DOM build ────────────────────────────────────────────────────── */
+
+  const announceEl = h("output", {
     class: "sr-only",
-    role: "status",
     "aria-live": "polite",
     "aria-atomic": "true",
-    text: announcement,
+    "data-bn-region": "play-announce",
+  });
+  bindText(announceEl, announcement);
+
+  /* Header / summary — mirrors SSR <header data-bn-region="play-summary">. */
+  const titleEl = h("h1", { id: "play-title", class: "sr-only" });
+  bindText(titleEl, () => `${session().category} — round #${session().id}`);
+
+  const numEl = h("small", { class: "lb-num" });
+  bindText(numEl, () => `#${session().id} · ${session().category.toLowerCase()}`);
+
+  const stickyEl = h("p", { class: "lb-sticky", "data-bn-region": "play-sticky" });
+  bindText(stickyEl, () => session().category);
+
+  const subBy = h("strong");
+  bindText(subBy, () => session().submittedBy || "?");
+  const subEl = h("p", { class: "lb-sub" });
+  effect(() => {
+    const s = session();
+    subEl.replaceChildren(
+      document.createTextNode(`${s.words.length} words · ${s.totalLetters} letters · by `),
+      subBy,
+    );
   });
 
-  // ── DOM build ──────────────────────────────────────────────────────────
-  const cbar = h("div", {
-    class: () => `lb-cbar${allInMode() && !casc() ? " lb-cbar-allin" : ""}`,
+  const hintEl = h("p", {
     role: "status",
     "aria-live": "polite",
-    text: () => {
-      if (casc()) return "⚡ Earned reveal — pick any tile in any unsolved word";
-      if (allInMode()) return `ALL IN — type the rest of the phrase · SHOVE to commit · +${allInBonus()} pts if right · 0 lives if wrong`;
-      return "";
-    },
-    hidden: () => !casc() && !allInMode(),
+    "data-bn-region": "play-hint",
+  });
+  bindText(hintEl, hintText);
+  bindClassName(hintEl, () => `lb-hint${active() !== null ? " on" : ""}`);
+
+  const cbarEl = h("p", {
+    role: "status",
+    "aria-live": "polite",
+    "data-bn-region": "play-cbar",
+  });
+  bindText(cbarEl, cbarText);
+  bindClassName(cbarEl, () => `lb-cbar${allInMode() && !casc() ? " lb-cbar-allin" : ""}`);
+  bindHidden(cbarEl, () => !casc() && !allInMode());
+
+  const summary = h("header", { "data-bn-region": "play-summary" },
+    titleEl,
+    h("p", { "data-bn-region": "play-meta" }, numEl),
+    stickyEl,
+    subEl,
+    hintEl,
+    cbarEl,
+  );
+
+  /* Phrase grid — single effect rebuilds on every relevant signal change.
+     One effect (rather than per-tile effects) is the same pattern PB's
+     bindList uses: when state changes, replaceChildren atomically.
+     Avoids the leaked-effects bug that per-tile subscriptions would
+     introduce when the session swaps to a different word count. */
+  const grid = h("section", {
+    class: "lb-phrase",
+    "aria-label": "Phrase grid",
+    "data-bn-region": "grid",
   });
 
-  const phraseGrid = h("div", { class: "lb-phrase" });
-  reactiveList(phraseGrid, () => {
+  effect(() => {
     const s = session();
-    const words = s.words;
+    const lockedAll = locked();
+    if (!s || lockedAll.length !== s.words.length) return;
+
     let allInNext = null;
     if (allInMode()) {
-      for (let wi = 0; wi < words.length; wi++) {
-        if (wordSolved()[wi]) continue;
-        const ss = openSlots(words[wi], locked()[wi]);
-        if (typed()[wi].length < ss.length) { allInNext = { wi, slotIdx: typed()[wi].length }; break; }
+      for (let w = 0; w < s.words.length; w++) {
+        if (wordSolved()[w]) continue;
+        const ss = openSlots(s.words[w], lockedAll[w]);
+        if (typed()[w].length < ss.length) {
+          allInNext = { wi: w, slotIdx: typed()[w].length };
+          break;
+        }
       }
     }
 
-    return words.map((wordLen, wi) => {
-      const lm = locked()[wi];
+    const wordEls = s.words.map((wordLen, wi) => {
+      const lm = lockedAll[wi];
       const slots = openSlots(wordLen, lm);
       const isAct = !allInMode() && active() === wi && !wordSolved()[wi] && !casc();
-      const cascOn = casc() && !wordSolved()[wi];
+      const wagerSet = new Set(wagers()[wi] || []);
       const fbW = feedback()[wi];
-      const wagerSet = new Set(wagers()[wi]);
 
-      const wordCls = [
-        "lb-word",
-        isAct ? "active" : "",
-        allInMode() && !wordSolved()[wi] ? "allin" : "",
-        wordSolved()[wi] ? "solved" : "",
-        shaking() === wi ? "shake" : "",
-        cascOn ? "casc-on" : "",
-      ].filter(Boolean).join(" ");
+      const wordCls = ["lb-word"];
+      if (isAct) wordCls.push("active");
+      if (allInMode() && !wordSolved()[wi]) wordCls.push("allin");
+      if (wordSolved()[wi]) wordCls.push("solved");
+      if (shaking() === wi) wordCls.push("shake");
+      if (casc() && !wordSolved()[wi]) wordCls.push("casc-on");
 
-      const wordEl = h("div", {
-        class: wordCls,
+      const word = h("div", {
+        role: "group",
+        class: wordCls.join(" "),
+        "aria-label": `Word ${wi + 1}`,
+        "data-word-index": wi,
         onClick: () => {
           if (casc() || allInMode()) return;
           if (!wordSolved()[wi]) active.set(wi);
@@ -389,26 +453,23 @@ export function createPlay({
         const lockedLetter = lm[li];
         const slotIdx = slots.indexOf(li);
         const typedLetter = slotIdx >= 0 ? typed()[wi][slotIdx] : null;
-        const isCursor = allInMode()
-          ? (allInNext?.wi === wi && allInNext?.slotIdx === slotIdx)
-          : (isAct && slotIdx === typed()[wi].length);
         const fbForTile = fbW?.find(f => f.idx === li);
         const isCascDrop = cascDrop() === `${wi}-${li}`;
         const isCascPick = casc() && lockedLetter === undefined && !wordSolved()[wi];
         const isWagered = slotIdx >= 0 && wagerSet.has(slotIdx) && typedLetter;
+        const isCursor = allInMode()
+          ? (allInNext?.wi === wi && allInNext?.slotIdx === slotIdx)
+          : (isAct && slotIdx === typed()[wi].length);
 
         const cls = ["lb-tile"];
-        let display;
-
-        if (wordSolved()[wi]) { cls.push("solved-tile"); display = lockedLetter; }
-        else if (lockedLetter !== undefined) {
-          cls.push("locked-green"); display = lockedLetter;
-        }
+        let display = "";
+        if (wordSolved()[wi]) { cls.push("solved-tile"); display = lockedLetter || ""; }
+        else if (lockedLetter !== undefined) { cls.push("locked-green"); display = lockedLetter; }
         else if (typedLetter) {
-          cls.push(allInMode() ? "typed allin-typed" : "typed");
+          cls.push("typed");
+          if (allInMode()) cls.push("allin-typed");
           display = typedLetter;
-        }
-        else { if (isCursor) cls.push("cursor"); display = ""; }
+        } else if (isCursor) cls.push("cursor");
 
         if (fbForTile) { cls.push("fb-flip", `fb-${fbForTile.status}`); display = fbForTile.letter; }
         if (isWagered) cls.push("wagered");
@@ -416,66 +477,84 @@ export function createPlay({
         if (isCascDrop) cls.push("casc-drop");
 
         const pos = `position ${li + 1} of word ${wi + 1}`;
-        let tileLabel;
-        if (wordSolved()[wi]) tileLabel = `${lockedLetter} at ${pos}, word solved`;
-        else if (lockedLetter !== undefined) tileLabel = `${lockedLetter} at ${pos}, locked`;
+        let label;
+        if (wordSolved()[wi]) label = `${lockedLetter} at ${pos}, word solved`;
+        else if (lockedLetter !== undefined) label = `${lockedLetter} at ${pos}, locked`;
         else if (typedLetter) {
           let state = "typed";
           if (isWagered) state += ", staked 2 times";
           if (isCursor) state += ", cursor here";
-          tileLabel = `${typedLetter} at ${pos}, ${state}`;
+          label = `${typedLetter} at ${pos}, ${state}`;
+        } else {
+          label = `Empty at ${pos}`;
+          if (isCursor) label += ", cursor here";
+          if (isCascPick) label += ", cascade reveal available";
         }
-        else {
-          tileLabel = `Empty at ${pos}`;
-          if (isCursor) tileLabel += ", cursor here";
-          if (isCascPick) tileLabel += ", cascade reveal available";
-        }
-        if (fbForTile) tileLabel = `${fbForTile.letter} at ${pos}, ${fbForTile.status}`;
+        if (fbForTile) label = `${fbForTile.letter} at ${pos}, ${fbForTile.status}`;
 
-        wordEl.append(h("div", {
-          class: cls.join(" "),
+        const tileProps = {
           role: "img",
-          "aria-label": tileLabel,
+          class: cls.join(" "),
+          "aria-label": label,
+          "data-word-index": wi,
+          "data-cell-index": li,
           onClick: (e) => {
             e.stopPropagation();
             if (isCascPick) { pickCascade(wi, li); return; }
             if ((isAct || allInMode()) && typedLetter) { toggleWager(wi, slotIdx); return; }
             if (!wordSolved()[wi] && !casc() && !allInMode()) active.set(wi);
           },
-        }, display));
+        };
+        if (lockedLetter !== undefined) tileProps["data-locked"] = "true";
+        word.append(h("span", tileProps, display));
       }
-      return wordEl;
+      return word;
     });
+
+    grid.replaceChildren(...wordEls);
   });
 
-  // Knowledge bank
-  const bankPresentRow = h("div", { class: "lb-bank-row" });
-  reactiveList(bankPresentRow, () => {
-    const out = [h("span", { class: "lb-bank-label" }, "in phrase:")];
+  /* Letter bank — present / absent chips. */
+  const presentRow = h("p", { class: "lb-bank-row", "data-bn-region": "bank-present" });
+  effect(() => {
     const pg = presentGlobal();
-    if (pg.length === 0) out.push(h("span", { class: "lb-bank-label" }, "—"));
-    else for (const L of pg) out.push(h("span", { class: "lb-chip yellow" }, L));
-    return out;
+    if (pg.length === 0) {
+      presentRow.replaceChildren(
+        h("span", { class: "lb-bank-label" }, "in phrase:"),
+        h("span", { class: "lb-bank-label" }, "—"),
+      );
+      return;
+    }
+    presentRow.replaceChildren(
+      h("span", { class: "lb-bank-label" }, "in phrase:"),
+      ...pg.map(L => h("span", { class: "lb-chip yellow" }, L)),
+    );
   });
-  const bankAbsentRow = h("div", { class: "lb-bank-row" });
-  reactiveList(bankAbsentRow, () => {
+
+  const absentRow = h("p", { class: "lb-bank-row", "data-bn-region": "bank-absent" });
+  effect(() => {
     const a = active();
-    if (a === null) return [];
+    if (a === null) { absentRow.replaceChildren(); return; }
     const abs = absentByWord()[a] || [];
-    if (abs.length === 0) return [];
-    return [
+    if (abs.length === 0) { absentRow.replaceChildren(); return; }
+    absentRow.replaceChildren(
       h("span", { class: "lb-bank-label" }, `not in word ${a + 1}:`),
       ...abs.map(L => h("span", { class: "lb-chip absent" }, L)),
-    ];
+    );
   });
-  const bank = h("div", { class: "lb-bank" }, bankPresentRow, bankAbsentRow);
 
-  // ── @basenative/keyboard wiring ──
+  const bank = h("section", {
+    class: "lb-bank",
+    "aria-label": "Letter bank",
+    "data-bn-region": "bank",
+  }, presentRow, absentRow);
+
+  /* Keyboard region — @basenative/keyboard mounts here. */
   const kb = Keyboard({
     layout: "qwerty",
     primary: "ENTER",
     label: "On-screen keyboard",
-    state: keyStatus,                  // computed → re-applies on signal change
+    state: keyStatus,
     runtime: { effect },
     onKey: typeLetter,
     onAction: (a) => {
@@ -483,59 +562,57 @@ export function createPlay({
       else if (a === "BACKSPACE") backspace();
     },
     haptic: true,
-    bindHardware: false,               // we have our own Esc/letter listener above
+    bindHardware: false,
   });
 
-  const kbWrap = h("div", {
-    class: () => `lb-kb-wrap${allInMode() ? " allin" : ""}`,
-    "aria-label": () => allInMode() ? "Keyboard in all-in mode" : "On-screen keyboard for game play",
-    role: "region",
-    hidden: () => phase() !== "playing",
-  });
-
-  // All-in toggle row
   const allInBtn = h("button", {
-    class: () => `lb-kb-allin${allInMode() ? " on" : ""}`,
+    class: "lb-kb-allin",
     type: "button",
+    "data-bn-action": "all-in",
     onClick: openAllIn,
-    "aria-label": () => allInMode() ? "Fold and resume normal play mode" : "Enter all-in mode: type all remaining letters and submit for bonus points or lose all lives",
-    text: () => allInMode() ? "FOLD" : "ALL IN",
-    disabled: () => casc() && !allInMode(),
   });
-  const stakeLbl = h("span", {
+  bindText(allInBtn, () => allInMode() ? "FOLD" : "ALL IN");
+  bindAttr(allInBtn, "aria-label", () => allInMode()
+    ? "Fold and resume normal play mode"
+    : "Enter all-in mode: type all remaining letters and submit for bonus points or lose all lives");
+  effect(() => {
+    allInBtn.classList.toggle("on", allInMode());
+    allInBtn.disabled = casc() && !allInMode();
+  });
+
+  const stakeLbl = h("output", {
     class: "lb-kb-stake",
     "aria-live": "polite",
-    "aria-label": () => {
-      const wagerCount = allInMode()
-        ? wagers().reduce((acc, w) => acc + (w?.length || 0), 0)
-        : (active() !== null ? (wagers()[active()]?.length || 0) : 0);
-      if (wagerCount > 0) return `${wagerCount} positions staked for 2 times points`;
-      if (allInMode()) return "Type the remaining letters of the phrase";
-      return "";
-    },
-    text: () => {
-      const wagerCount = allInMode()
-        ? wagers().reduce((acc, w) => acc + (w?.length || 0), 0)
-        : (active() !== null ? (wagers()[active()]?.length || 0) : 0);
-      if (wagerCount > 0) return `${wagerCount}× STAKED`;
-      if (allInMode()) return "TYPE THE REST";
-      return "";
-    },
+    "data-bn-region": "stake-label",
+  });
+  bindText(stakeLbl, stakeText);
+  bindAttr(stakeLbl, "aria-label", () => {
+    const wagerCount = allInMode()
+      ? wagers().reduce((acc, w) => acc + (w?.length || 0), 0)
+      : (active() !== null ? (wagers()[active()]?.length || 0) : 0);
+    if (wagerCount > 0) return `${wagerCount} positions staked for 2 times points`;
+    if (allInMode()) return "Type the remaining letters of the phrase";
+    return null;
   });
 
-  const kbActions = h("div", { class: "lb-kb-actions" }, allInBtn, stakeLbl);
+  const kbActions = h("footer", { class: "lb-kb-actions" }, allInBtn, stakeLbl);
   const kbHost = h("div", { html: kb.html });
-  kbWrap.append(kbActions, kbHost);
-  // Hydrate the keyboard once it's in the tree.
+
+  const keyboard = h("section", {
+    class: "lb-kb-wrap",
+    "aria-label": "On-screen keyboard",
+    "data-bn-region": "keyboard",
+  }, kbActions, kbHost);
+  bindClassName(keyboard, () => `lb-kb-wrap${allInMode() ? " allin" : ""}`);
+  bindHidden(keyboard, () => phase() !== "playing");
+
   queueMicrotask(() => {
     const root = kbHost.querySelector('[data-bn="keyboard"]');
     if (!root) return;
     kb.hydrate(root);
-    // iPhone workaround: @basenative/keyboard@1.0.0's preventFocusSteal
-    // calls preventDefault on touchstart, which on iOS Safari suppresses
-    // the synthetic click that the keyboard's dispatch handler relies on.
-    // Synthesize a click on touchend so the dispatch fires on iPhone.
-    // Drop this once the package bumps to 1.0.1 (fix lands upstream).
+    /* iOS Safari: @basenative/keyboard@1.0.0 calls preventDefault on
+       touchstart, suppressing the synthetic click the dispatcher relies
+       on. Synthesize the click on touchend until the upstream fix lands. */
     root.addEventListener("touchend", (e) => {
       const btn = e.target && e.target.closest && e.target.closest("[data-bn-kb-key]");
       if (!btn || btn.disabled) return;
@@ -544,99 +621,65 @@ export function createPlay({
     }, { passive: false });
   });
 
-  // ── End-state overlays ──
-  const wonOverlay = createEndOverlay({
-    open: () => phase() === "won" && !!reveal(),
-    title: "Solved",
-    titleClass: "lb-ct win",
-    session,
-    score,
-    reveal,
-    onShare: () => onShare({ won: true }).then(label => shareLbl.set(label)),
-    shareLbl,
-    primaryLabel: "Pick another",
-    onPrimary: goLobby,
-    secondary: null,
+  /* End-of-round dialog — single <dialog> element, contents swap by phase. */
+  const endTitle  = h("h2", { class: "lb-ct" });
+  const endSub    = h("p", { class: "lb-cs" });
+  const endReveal = h("p", { class: "lb-reveal" });
+  const endBy     = h("strong");
+  const endCredit = h("p", { class: "lb-cred" }, "submitted by ", endBy);
+  const endScore  = h("output", { class: "lb-cf", "data-bn-region": "end-score" });
+  const endShare  = h("button", {
+    class: "lb-btn lb-bp",
+    type: "button",
+    "data-bn-action": "share",
   });
+  const endPrimary   = h("button", { class: "lb-btn lb-bs", type: "button", "data-bn-action": "primary" });
+  const endSecondary = h("button", { class: "lb-btn", type: "button", "data-bn-action": "secondary" });
 
-  const lostOverlay = createEndOverlay({
-    open: () => phase() === "lost" && !!reveal(),
-    title: "House Wins",
-    titleClass: "lb-ct lose",
-    session,
-    score,
-    reveal,
-    onShare: () => onShare({ won: false }).then(label => shareLbl.set(label)),
-    shareLbl,
-    primaryLabel: "Try again",
-    onPrimary: () => retry(),
-    secondaryLabel: "Pick another",
-    onSecondary: goLobby,
-    subtitleSuffix: " · the answer was",
+  bindText(endScore, () => String(score()));
+  bindAttr(endScore, "aria-label", () => `Final score ${score()} points`);
+  bindText(endShare, () => shareLbl() || "Share result");
+  bindText(endBy, () => session().submittedBy || "?");
+  bindText(endTitle, () => phase() === "won" ? "Solved" : "House Wins");
+  bindClassName(endTitle, () => `lb-ct ${phase() === "won" ? "win" : "lose"}`);
+  bindText(endSub, () => `${session().category}${phase() === "lost" ? " · the answer was" : ""}`);
+  bindText(endReveal, () => (reveal() || []).join(" "));
+  bindText(endPrimary, () => phase() === "won" ? "Pick another" : "Try again");
+  endSecondary.textContent = "Pick another";
+  bindHidden(endSecondary, () => phase() !== "lost");
+
+  endShare.addEventListener("click", () => {
+    onShare({ won: phase() === "won" }).then(label => shareLbl.set(label));
   });
+  endPrimary.addEventListener("click", () => {
+    if (phase() === "won") goLobby();
+    else retry();
+  });
+  endSecondary.addEventListener("click", goLobby);
 
-  return h("div", { class: "lb-play-host" },
-    ariaLive,
-    h("main", { "aria-labelledby": "lb-play-title" },
-      h("h1", { id: "lb-play-title", class: "sr-only", text: () => `${session().category} — round #${session().id}` }),
-      h("div", { class: "lb-num", text: () => `#${session().id} · ${session().category.toLowerCase()}` }),
-      h("div", { class: "lb-sticky", text: () => session().category }),
-      h("div", { class: "lb-sub" },
-        () => `${session().words.length} words · ${session().totalLetters} letters · by `,
-        h("b", { text: () => session().submittedBy || "?" }),
-      ),
-      h("div", {
-        class: () => `lb-hint ${active() !== null ? "on" : ""}`,
-        "aria-live": "polite",
-        text: hintText,
-      }),
-      cbar,
-      phraseGrid,
-      bank,
-    ),
-    kbWrap,
-    wonOverlay,
-    lostOverlay,
-  );
-}
-
-function createEndOverlay({
-  open, title, titleClass,
-  session, score, reveal,
-  onShare, shareLbl,
-  primaryLabel, onPrimary,
-  secondaryLabel, onSecondary,
-  subtitleSuffix = "",
-}) {
-  const card = h("div", {
+  const endCard = h("article", {
     class: "lb-card",
-    role: "dialog",
-    "aria-modal": "true",
+    role: "document",
     onClick: (e) => e.stopPropagation(),
   },
-    h("div", { class: titleClass, text: title }),
-    h("div", { class: "lb-cs", text: () => `${session().category}${subtitleSuffix}` }),
-    h("div", { class: "lb-reveal", text: () => (reveal() || []).join(" ") }),
-    h("div", { class: "lb-cred" },
-      "submitted by ",
-      h("b", { text: () => session().submittedBy || "?" })
-    ),
-    h("div", { class: "lb-cf", "aria-label": () => `Final score ${score()} points`, text: () => String(score()) }),
-    h("div", { class: "lb-cfl" }, "points"),
-    h("button", {
-      class: "lb-btn lb-bp",
-      type: "button",
-      text: () => shareLbl() || "Share result",
-      onClick: onShare,
-    }),
-    secondaryLabel
-      ? h("button", { class: "lb-btn", type: "button", onClick: onSecondary }, secondaryLabel)
-      : null,
-    h("button", { class: "lb-btn lb-bs", type: "button", onClick: onPrimary }, primaryLabel),
+    endTitle, endSub, endReveal, endCredit,
+    endScore, h("p", { class: "lb-cfl" }, "points"),
+    endShare, endSecondary, endPrimary,
   );
 
-  return h("div", {
+  const endOverlay = h("div", {
     class: "lb-ov",
-    hidden: () => !open(),
-  }, card);
+    role: "dialog",
+    "aria-modal": "true",
+    "aria-labelledby": "play-end-title",
+    "data-bn-region": "end-overlay",
+  }, endCard);
+  endTitle.id = "play-end-title";
+  bindHidden(endOverlay, () => !((phase() === "won" || phase() === "lost") && !!reveal()));
+
+  /* ── Root <main>: same shape as src/bn/views/play.js SSR template. ── */
+  return h("main", {
+    "aria-labelledby": "play-title",
+    "data-bn-view": "play",
+  }, announceEl, summary, grid, bank, keyboard, endOverlay);
 }

--- a/src/views/submit.js
+++ b/src/views/submit.js
@@ -1,11 +1,14 @@
-/* Single-file component: SUBMIT view.
-   Posts to /api/submit with category + phrase. Live tile preview.
-   Existing categories drive the @basenative/combobox typeahead, with
-   `allowCreate` for new categories. */
+/* SUBMIT view — semantic mirror of src/bn/views/submit.js (SSR).
+
+   <main data-bn-view="submit"> with a real <form>, <fieldset>, <legend>,
+   <label>, <input>, <datalist>, and <output role="alert">. The combobox
+   from @basenative/combobox sits inside the category <label>; the live
+   tile preview is a <section data-bn-region="preview">. */
 
 import { signal, computed, effect } from "@basenative/runtime";
 import { Combobox } from "@basenative/combobox";
-import { h, reactiveList } from "../lib/dom.js";
+import { h } from "../lib/dom.js";
+import { bindDisabled, bindHidden, bindList, bindText } from "../lib/bind.js";
 import { api } from "../lib/api.js";
 
 export function createSubmit({ existingCategories, onCancel, onSubmitted, toaster }) {
@@ -15,127 +18,156 @@ export function createSubmit({ existingCategories, onCancel, onSubmitted, toaste
   const err      = signal(null);
 
   const cleaned = computed(() =>
-    phrase().trim().toUpperCase().replace(/[^A-Z ]/g, "").replace(/\s+/g, " ")
+    phrase().trim().toUpperCase().replace(/[^A-Z ]/g, "").replace(/\s+/g, " "),
   );
   const words = computed(() => cleaned() ? cleaned().split(" ") : []);
   const totalLetters = computed(() => words().reduce((a, w) => a + w.length, 0));
 
-  async function submit() {
+  async function submit(e) {
+    if (e) e.preventDefault();
     busy.set(true); err.set(null);
     try {
       await api.submit({ category: category().trim(), phrase: cleaned(), anchors: [] });
       toaster("SUBMITTED — pending review", "great");
       onSubmitted();
-    } catch (e) {
-      err.set(String(e.data?.detail || e.message || e));
+    } catch (e2) {
+      err.set(String(e2.data?.detail || e2.message || e2));
     } finally {
       busy.set(false);
     }
   }
 
-  // Combobox: signal-driven, allowCreate, runtime.effect hooks the
-  // input value back to the category signal.
+  /* Combobox lives inside the category <label>. */
   const cb = Combobox({
-    id: "lb-cat",
+    id: "submit-category",
     name: "category",
     options: existingCategories() || [],
     value: category,
     allowCreate: true,
     createLabel: (input) => `+ NEW CATEGORY "${input.toUpperCase()}"`,
     placeholder: "Pick or add a category",
-    ariaDescribedBy: "lb-cat-hint",
+    ariaDescribedBy: "submit-cat-hint",
     onChange: (v) => category.set(String(v).toUpperCase()),
     onCreate: (label) => category.set(String(label).toUpperCase()),
     runtime: { effect },
   });
 
-  // Wrapper element receives the combobox HTML; hydrate after the
-  // wrapper is appended to the DOM (bind: ref runs synchronously,
-  // before mount, so we wait one microtask via queueMicrotask).
-  const cbWrapper = h("div", {
-    class: "lb-cat-combobox",
+  const cbWrapper = h("span", {
+    "data-bn-bind": "submit-combobox",
+    "data-suggestions-id": "submit-categories",
     html: cb.html,
     bind: (el) => {
       const handle = cb.hydrate(el);
-      // Mirror existingCategories changes back into the listbox.
       effect(() => handle.setOptions(existingCategories() || []));
     },
   });
 
+  /* Hint texts. */
+  const catHint = h("small", { id: "submit-cat-hint" });
+  bindText(catHint, () => existingCategories()?.length > 0
+    ? `Tap to pick from ${existingCategories().length} existing categories, or type a new one.`
+    : "Type a category name. New categories show up here once approved.",
+  );
+
+  const phraseHint = h("small", { id: "submit-phrase-hint", "data-bn-bind": "submit-phrase-hint" });
+  bindText(phraseHint, () => `${words().length} word${words().length === 1 ? "" : "s"} · ${totalLetters()} letters · max 36`);
+
+  /* Live tile preview. */
+  const preview = h("section", {
+    class: "lb-preview",
+    "aria-label": "Phrase preview",
+    "aria-hidden": "true",
+    "data-bn-region": "preview",
+    "data-bn-bind": "submit-preview",
+  });
+  bindList(preview, words, (word) =>
+    h("div", { class: "lb-pword", role: "group" },
+      ...word.split("").map(() => h("span", { class: "lb-ptile", role: "img", "aria-label": "tile" })),
+    ),
+  () => h("p", null, "Type a phrase to see how it'll render."));
+
+  const previewHint = h("small", { class: "lb-fhint" });
+  bindText(previewHint, () => words().length === 0
+    ? "Type a phrase above to see how it'll render."
+    : "No starting hints. Players solve it cold.",
+  );
+
+  /* Error output. */
+  const errBox = h("output", {
+    class: "lb-ferror",
+    role: "alert",
+    "data-bn-bind": "submit-error",
+  });
+  bindText(errBox, () => err() || "");
+  bindHidden(errBox, () => !err());
+
+  /* Phrase input. */
   const phraseInput = h("input", {
-    id: "lb-phrase",
+    id: "submit-phrase",
+    name: "phrase",
     class: "lb-finput",
     autocapitalize: "characters",
     autocorrect: "off",
     spellcheck: "false",
     placeholder: "2–10 words · letters only",
-    "aria-describedby": "lb-phrase-hint",
+    "aria-describedby": "submit-phrase-hint",
     onInput: (e) => phrase.set(e.target.value),
   });
 
-  const preview = h("div", {
-    class: () => `lb-preview${words().length === 0 ? " empty" : ""}`,
-    "aria-hidden": "true",
+  const submitBtn = h("button", {
+    type: "submit",
+    class: "lb-btn lb-bp",
+    "data-bn-action": "submit-confirm",
   });
-  reactiveList(preview, () => {
-    const w = words();
-    if (w.length === 0) return [document.createTextNode("Tiles preview as you type")];
-    return w.map(word =>
-      h("div", { class: "lb-pword" },
-        ...word.split("").map(() => h("div", { class: "lb-ptile" })),
-      )
-    );
-  });
+  bindText(submitBtn, () => busy() ? "…" : "SUBMIT FOR REVIEW");
+  bindDisabled(submitBtn, () => busy() || !category() || !phrase());
 
-  const errBox = h("div", {
-    class: "lb-ferror",
-    text: () => err() || "",
-    hidden: () => !err(),
-  });
+  const cancelBtn = h("button", {
+    type: "button",
+    class: "lb-btn lb-bs",
+    "data-bn-action": "submit-cancel",
+    onClick: onCancel,
+  }, "Cancel");
 
-  return h("main", { "aria-labelledby": "lb-submit-title" },
-    h("h1", { id: "lb-submit-title", class: "sr-only" }, "Submit a phrase"),
-    h("div", { class: "lb-sticky lb-sticky-narrow" }, "Submit a phrase"),
-    h("div", { class: "lb-tagline" }, "It enters the moderation queue"),
-    h("div", { class: "lb-form" },
-      h("div", { class: "lb-field" },
+  const form = h("form", {
+    class: "lb-form",
+    "data-bn-action": "submit-form",
+    "aria-describedby": "submit-hint",
+    novalidate: "",
+    onSubmit: submit,
+  },
+    h("fieldset", null,
+      h("legend", null, "New round"),
+      h("p", { class: "lb-field" },
+        h("label", { for: "submit-category" }, "Category"),
         cbWrapper,
-        h("span", {
-          id: "lb-cat-hint",
-          class: "lb-fhint",
-          text: () => existingCategories()?.length > 0
-            ? `Tap to pick from ${existingCategories().length} existing categories, or type a new one.`
-            : "Type a category name. New categories show up here once approved.",
-        }),
+        catHint,
       ),
-      h("div", { class: "lb-field" },
-        h("label", { class: "lb-flabel", for: "lb-phrase" }, "Phrase"),
+      h("p", { class: "lb-field" },
+        h("label", { for: "submit-phrase" }, "Phrase"),
         phraseInput,
-        h("span", {
-          id: "lb-phrase-hint",
-          class: "lb-fhint",
-          text: () => `${words().length} word${words().length === 1 ? "" : "s"} · ${totalLetters()} letters · max 36`,
-        }),
+        phraseHint,
       ),
-      h("div", { class: "lb-field" },
+      h("p", { class: "lb-field" },
         h("span", { class: "lb-flabel" }, "Preview"),
         preview,
-        h("span", {
-          class: "lb-fhint",
-          text: () => words().length === 0
-            ? "Type a phrase above to see how it'll render."
-            : "No starting hints. Players solve it cold.",
-        }),
+        previewHint,
       ),
       errBox,
     ),
-    h("button", {
-      class: "lb-btn lb-bp",
-      type: "button",
-      disabled: () => busy() || !category() || !phrase(),
-      text: () => busy() ? "…" : "SUBMIT FOR REVIEW",
-      onClick: submit,
-    }),
-    h("button", { class: "lb-btn lb-bs", type: "button", onClick: onCancel }, "Cancel"),
+    submitBtn,
+    cancelBtn,
+  );
+
+  return h("main", {
+    "aria-labelledby": "submit-title",
+    "data-bn-view": "submit",
+  },
+    h("header", null,
+      h("h1", { id: "submit-title", class: "sr-only" }, "Submit a phrase"),
+      h("p", { class: "lb-sticky lb-sticky-narrow" }, "Submit a phrase"),
+      h("p", { class: "lb-tagline" }, "It enters the moderation queue"),
+    ),
+    form,
   );
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,8 +4,33 @@ import { createMockApi } from "./server/mock.js";
 
 const indexEntry     = fileURLToPath(new URL("./index.html",                 import.meta.url));
 const bnHydrateEntry = fileURLToPath(new URL("./src/bn/client/hydrate.js",   import.meta.url));
+const bnExprShim     = fileURLToPath(new URL("./src/_shims/bn-runtime-expression.js", import.meta.url));
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      /* @basenative/runtime@0.4.0 ships a broken monorepo-relative
+         import for shared/expression.js. The SPA never touches the
+         expression evaluator; redirect the unresolvable path to a
+         local stub so Vite can build. Drop this once the upstream
+         tarball is fixed. */
+      { find: "../../../src/shared/expression.js", replacement: bnExprShim },
+    ],
+  },
+  /* Exclude @basenative/* from esbuild's pre-bundling so resolve.alias
+     above runs against the runtime's broken import (esbuild's optimizer
+     bypasses Vite aliases for sub-deps). */
+  optimizeDeps: {
+    exclude: [
+      "@basenative/runtime",
+      "@basenative/router",
+      "@basenative/persist",
+      "@basenative/keyboard",
+      "@basenative/combobox",
+      "@basenative/share",
+      "@basenative/admin/components",
+    ],
+  },
   plugins: [
     {
       name: "tabs-mock-api",


### PR DESCRIPTION
## Summary

The SPA views were emitting class-heavy `<div>` soup that bore no resemblance to the SSR templates in `src/bn/views/` or to PendingBusiness's signal-bind pattern. This PR rewrites the four user-facing views to produce the same semantic shape the SSR side already does, so the runtime DOM matches what crawlers see and what the rest of the BaseNative-built apps look like.

- New `src/lib/bind.js` — PB-style `bindText` / `bindAttr` / `bindClass` / `bindHidden` / `bindList` helpers that wrap `effect()` from `@basenative/runtime` and apply targeted DOM mutations to existing nodes.
- `src/views/play.js`, `lobby.js`, `submit.js`, `moderate.js` rewritten to use semantic HTML (`<main>`, `<header>`, `<section>`, `<output>`, `<fieldset>`, `<legend>`, `<label>`, `<article>`) and `data-bn-view` / `data-bn-region` / `data-bn-bind` / `data-bn-action` attributes that mirror the SSR templates. The phrase grid uses a single recompute effect (PB's `bindList` pattern) instead of per-tile effects, which avoids leaked subscriptions across session swaps.
- `bindHidden` toggles **both** the `hidden` attribute and a `.is-hidden` class so it wins over flex/grid display rules in `styles.css`.
- Existing `lb-*` styling classes are preserved so no CSS rewrite is needed in this PR; the structural change is in the elements + attributes.

### Build workaround

The deployed `@basenative/runtime@0.4.0` tarball ships with a broken monorepo-relative import (`evaluate.js` and `scope.js` reference `../../../src/shared/expression.js`, which doesn't exist after install). PendingBusiness sidesteps this by writing a local `signals.ts` shim. We added a Vite `resolve.alias` + tiny stub at `src/_shims/bn-runtime-expression.js` (the SPA never reaches the expression evaluator) plus `optimizeDeps.exclude` so esbuild doesn't pre-bundle around the alias. Drops out the moment the upstream tarball is fixed.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `vite dev` boots, lobby renders semantic HTML
- [x] `/play?play=N` renders the play view, typing letters + Enter submits a guess and tiles flip with the right feedback colors
- [x] `/submit` renders the form with combobox + live tile preview
- [x] `/moderate` renders the queue (empty state)
- [x] Zero console errors / warnings across all four routes
- [ ] Verify on Cloudflare Pages preview after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)