### PR TITLE
fix: null guards for runtime crash + daily game mode

### DIFF
--- a/src/bn/client/hydrate.js
+++ b/src/bn/client/hydrate.js
@@ -23,7 +23,7 @@ import {
 import { nativeShare, mintShareCard, composeShareText } from "@basenative/share/client";
 
 import { api } from "../../lib/api.js";
-import { groupLobby } from "../../lib/game.js";
+import { groupLobby, dailyPuzzle } from "../../lib/game.js";
 import { mount, h } from "../../lib/dom.js";
 import { createHeader }    from "../../components/header.js";
 import { createToast, makeToaster } from "../../components/toast.js";
@@ -213,6 +213,23 @@ if (!SSR.user) {
   }
 })();
 
+/* ── Daily auto-start ────────────────────────────────────────────────
+   When the lobby finishes loading and the user isn't already in a
+   round, auto-start today's daily puzzle so every visitor sees the
+   same puzzle per day (Wordle-style). Only fires once. */
+let dailyFired = false;
+effect(() => {
+  const lb = lobby();
+  if (!lb || dailyFired) return;
+  /* Don't interrupt an active game or a resume in progress */
+  if (session() || playLoading()) return;
+  /* Only auto-start from the lobby — respect deep-links to other views */
+  if (view() !== "lobby") return;
+  dailyFired = true;
+  const pick = dailyPuzzle(lb);
+  if (pick) start(pick.id);
+});
+
 function hydrateSession(s, fresh) {
   const lm = s.words.map(() => ({}));
   s.anchors.forEach(a => { lm[a.wi][a.li] = a.letter; });
@@ -259,6 +276,7 @@ async function start(puzzleId) {
 async function shareResult({ won }) {
   try {
     const s = session();
+    if (!s?.words) return "Couldn't share";
     const sLocked = locked();
     const sPos = posFeedback();
     const grid = s.words.map((len, wi) => {

--- a/src/bn/client/play-boot.js
+++ b/src/bn/client/play-boot.js
@@ -18,8 +18,9 @@
 /**
  * @typedef {{ kind: "start", puzzleId: number }} StartIntent
  * @typedef {{ kind: "resume", sessionId: string }} ResumeIntent
+ * @typedef {{ kind: "daily" }} DailyIntent
  * @typedef {{ kind: "home" }} HomeIntent
- * @typedef {StartIntent | ResumeIntent | HomeIntent} BootIntent
+ * @typedef {StartIntent | ResumeIntent | DailyIntent | HomeIntent} BootIntent
  */
 
 /**

--- a/src/lib/game.js
+++ b/src/lib/game.js
@@ -52,4 +52,32 @@ export function groupLobby(lobby) {
   return [...map.values()].sort((a, b) => a.category.localeCompare(b.category));
 }
 
+/* Date-seeded deterministic selection — everyone sees the same puzzle
+   for a given day. Uses a simple hash of the YYYY-MM-DD string to pick
+   an index from the available puzzle list. */
+export function dailySeed(date = new Date()) {
+  const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+  let h = 0;
+  for (let i = 0; i < key.length; i++) {
+    h = ((h << 5) - h + key.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+/** Pick today's puzzle from a flat list of puzzles. Returns null if the list is empty. */
+export function dailyPuzzle(puzzles, date = new Date()) {
+  if (!puzzles || puzzles.length === 0) return null;
+  const seed = dailySeed(date);
+  return puzzles[seed % puzzles.length];
+}
+
+/** Pick today's category and puzzle from grouped lobby data. */
+export function dailyFromGroups(groups, date = new Date()) {
+  if (!groups || groups.length === 0) return null;
+  const seed = dailySeed(date);
+  const group = groups[seed % groups.length];
+  const puzzle = group.puzzles[seed % group.puzzles.length];
+  return { group, puzzle };
+}
+
 export const isDev = () => !!(import.meta && import.meta.env && import.meta.env.DEV);

--- a/src/styles.css
+++ b/src/styles.css
@@ -324,6 +324,25 @@ body { font-family: 'DM Sans', sans-serif; color: #F0EDE4; }
   font-size: 10px; letter-spacing: 1.2px; color: #9A9590; text-transform: uppercase;
 }
 
+/* DAILY */
+.lb-daily {
+  width: 100%; max-width: 480px;
+  display: flex; flex-direction: column; gap: 6px;
+  margin-bottom: 18px; text-align: center;
+}
+.lb-daily-label {
+  font-size: 10px; letter-spacing: 2px; text-transform: uppercase;
+  color: #E8920A; font-weight: 700;
+}
+.lb-daily-item {
+  border-color: #E8920A !important;
+  background: #1A1714 !important;
+}
+.lb-lobby-daily {
+  border-color: #E8920A;
+  position: relative;
+}
+
 .lb-tagline { font-size: 11px; color: #9A9590; letter-spacing: 1.2px; text-transform: uppercase; margin-bottom: 18px; text-align: center; }
 
 .lb-stats {

--- a/src/views/lobby.js
+++ b/src/views/lobby.js
@@ -7,7 +7,7 @@
 import { computed } from "@basenative/runtime";
 import { h } from "../lib/dom.js";
 import { bindHidden, bindList, bindText } from "../lib/bind.js";
-import { groupLobby } from "../lib/game.js";
+import { groupLobby, dailyFromGroups } from "../lib/game.js";
 
 export function createLobby({
   lobby,
@@ -20,6 +20,7 @@ export function createLobby({
   void user; // accepted for parity with hydrate.js wiring; unused right now
 
   const groups = computed(() => groupLobby(lobby()));
+  const daily  = computed(() => dailyFromGroups(groups()));
   const hasStats = computed(() => (stats()?.played || 0) > 0);
 
   /* Stats — three little chips, only visible after the first played round. */
@@ -41,6 +42,33 @@ export function createLobby({
   );
   bindHidden(statsSection, () => !hasStats());
 
+  /* Daily puzzle card — today's deterministic pick. Hidden until lobby
+     loads. Built from static nodes + bindText so the structure mirrors
+     statsSection rather than reaching for an `effect()` rebuild. */
+  const dailyCat = h("strong", { class: "lb-lobby-cat" });
+  const dailyBy  = h("small", { class: "lb-lobby-by" });
+  bindText(dailyCat, () => daily()?.group?.category || "");
+  bindText(dailyBy,  () => daily() ? `by ${daily().puzzle.submittedBy}` : "");
+  const dailyBtn = h("button", {
+    type: "button",
+    class: "lb-lobby-item lb-daily-item",
+    "data-bn-action": "lobby-pick",
+    onClick: () => { const d = daily(); if (d) onPick(d.puzzle.id); },
+  },
+    h("span", { class: "sr-only" }, "Play today's puzzle: "),
+    dailyCat,
+    dailyBy,
+  );
+  const dailyCard = h("section", {
+    class: "lb-daily",
+    "aria-label": "Today's puzzle",
+    "data-bn-region": "daily",
+  },
+    h("p", { class: "lb-daily-label" }, "Today's puzzle"),
+    dailyBtn,
+  );
+  bindHidden(dailyCard, () => !daily());
+
   /* Error — single status paragraph, hidden by default. */
   const errorEl = h("p", {
     class: "lb-cred lb-cred-error",
@@ -58,17 +86,24 @@ export function createLobby({
     "data-bn-region": "list",
   });
   bindList(list, groups, (group) => {
+    const d = daily();
+    const isDaily = d?.group?.category === group.category;
     const credit = group.puzzles.length === 1
       ? `by ${group.puzzles[0].submittedBy}`
       : `${group.puzzles.length} puzzles`;
     return h("li", null,
       h("button", {
         type: "button",
-        class: "lb-lobby-item",
+        class: `lb-lobby-item${isDaily ? " lb-lobby-daily" : ""}`,
         "data-bn-action": "lobby-pick",
         "data-puzzle-ids": group.puzzles.map(p => p.id).join(","),
         onClick: () => {
-          const pick = group.puzzles[Math.floor(Math.random() * group.puzzles.length)];
+          /* Deterministic daily pick for the featured category, random
+             for everything else — keeps the daily reproducible across
+             players while preserving variety in the rest of the list. */
+          const pick = isDaily && d
+            ? d.puzzle
+            : group.puzzles[Math.floor(Math.random() * group.puzzles.length)];
           onPick(pick.id);
         },
       },
@@ -108,6 +143,7 @@ export function createLobby({
     ),
     statsSection,
     errorEl,
+    dailyCard,
     h("section", { "aria-labelledby": "lobby-list-title" },
       h("h2", { id: "lobby-list-title", class: "sr-only" }, "Available puzzles"),
       list,

--- a/src/views/play.js
+++ b/src/views/play.js
@@ -36,8 +36,9 @@ export function createPlay({
 }) {
   /* ── per-round UI signals ──────────────────────────────────────────── */
   const active     = signal(null);
-  const typed      = signal(session.peek().words.map(() => []));
-  const wagers     = signal(session.peek().words.map(() => []));
+  const s0         = session.peek() || { words: [] };
+  const typed      = signal(s0.words.map(() => []));
+  const wagers     = signal(s0.words.map(() => []));
   const allInMode  = signal(false);
   const casc       = signal(false);
   const feedback   = signal({});       // wi -> [{idx, letter, status}]
@@ -60,8 +61,9 @@ export function createPlay({
     if (phase() !== "playing") return "";
     if (active() === null) return "";
     const s = session();
-    const slots = openSlots(s.words[active()], locked()[active()]);
-    const room = slots.length - typed()[active()].length;
+    if (!s?.words) return "";
+    const slots = openSlots(s.words[active()], locked()[active()] || {});
+    const room = slots.length - (typed()[active()]?.length || 0);
     if (room === 0) return "Word complete. Press enter to submit or tap a tile to stake 2× points.";
     return `Type ${room} more letter${room === 1 ? "" : "s"} for word ${active() + 1}.`;
   });
@@ -72,7 +74,11 @@ export function createPlay({
     return "";
   });
 
-  const allInBonus = computed(() => fullCount(session().words, locked()) * 8);
+  const allInBonus = computed(() => {
+    const s = session();
+    if (!s?.words) return 0;
+    return fullCount(s.words, locked()) * 8;
+  });
 
   const stakeText = computed(() => {
     const wagerCount = allInMode()
@@ -113,11 +119,11 @@ export function createPlay({
   /* ── typing primitives ─────────────────────────────────────────────── */
   const findGlobalNextSlot = () => {
     const s = session();
-    if (!s) return null;
+    if (!s?.words) return null;
     for (let wi = 0; wi < s.words.length; wi++) {
       if (wordSolved()[wi]) continue;
-      const slots = openSlots(s.words[wi], locked()[wi]);
-      if (typed()[wi].length < slots.length) return { wi, slotIdx: typed()[wi].length };
+      const slots = openSlots(s.words[wi], locked()[wi] || {});
+      if ((typed()[wi]?.length || 0) < slots.length) return { wi, slotIdx: typed()[wi]?.length || 0 };
     }
     return null;
   };
@@ -133,8 +139,10 @@ export function createPlay({
     const a = active();
     if (a === null) return;
     if (wordSolved()[a]) return;
-    const slots = openSlots(session().words[a], locked()[a]);
-    if (typed()[a].length >= slots.length) return;
+    const s = session();
+    if (!s?.words) return;
+    const slots = openSlots(s.words[a], locked()[a] || {});
+    if ((typed()[a]?.length || 0) >= slots.length) return;
     typed.set(prev => prev.map((t, i) => i !== a ? t : [...t, letter]));
   };
 
@@ -142,7 +150,9 @@ export function createPlay({
     if (phase() !== "playing" || casc()) return;
     if (allInMode()) {
       const t = typed();
-      for (let wi = session().words.length - 1; wi >= 0; wi--) {
+      const s = session();
+      if (!s?.words) return;
+      for (let wi = s.words.length - 1; wi >= 0; wi--) {
         if ((t[wi]?.length || 0) > 0) {
           typed.set(prev => prev.map((row, i) => i !== wi ? row : row.slice(0, -1)));
           wagers.set(prev => prev.map((w, i) => i !== wi ? w : w.filter(s => s < (t[wi].length - 1))));
@@ -178,8 +188,9 @@ export function createPlay({
   async function submit(wi) {
     if (phase() !== "playing" || casc() || wordSolved()[wi]) return;
     const s = session();
+    if (!s?.words) return;
     const wordLen = s.words[wi];
-    const lm = locked()[wi];
+    const lm = locked()[wi] || {};
     const slots = openSlots(wordLen, lm);
     if (typed()[wi].length < slots.length) {
       shaking.set(wi); setTimeout(() => shaking.set(null), 480);
@@ -243,9 +254,11 @@ export function createPlay({
 
   async function pickCascade(wi, li) {
     if (!casc() || tokens() <= 0 || wordSolved()[wi]) return;
-    if (locked()[wi][li] !== undefined) return;
+    if ((locked()[wi] || {})[li] !== undefined) return;
+    const s = session();
+    if (!s) return;
     try {
-      const result = await api.cascade(session().sessionId, wi, li);
+      const result = await api.cascade(s.sessionId, wi, li);
       locked.set(prev => prev.map((m, i) => i !== wi ? m : { ...result.locked }));
       tokens.set(result.tokens);
       presentGlobal.set(result.presentGlobal);
@@ -266,8 +279,10 @@ export function createPlay({
       announcement.set("Fold. Returned to normal play.");
       return;
     }
-    typed.set(session().words.map(() => []));
-    wagers.set(session().words.map(() => []));
+    const s = session();
+    if (!s?.words) return;
+    typed.set(s.words.map(() => []));
+    wagers.set(s.words.map(() => []));
     active.set(null);
     allInMode.set(true);
     announcement.set("All-in mode. Type the rest of the phrase to shove.");
@@ -275,9 +290,9 @@ export function createPlay({
 
   async function submitAllIn() {
     const s = session();
-    if (!s || !allInMode()) return;
+    if (!s?.words || !allInMode()) return;
     const guesses = s.words.map((len, wi) => {
-      const lm = locked()[wi];
+      const lm = locked()[wi] || {};
       const slots = openSlots(len, lm);
       let str = "";
       for (let i = 0; i < len; i++) {
@@ -351,19 +366,26 @@ export function createPlay({
 
   /* Header / summary — mirrors SSR <header data-bn-region="play-summary">. */
   const titleEl = h("h1", { id: "play-title", class: "sr-only" });
-  bindText(titleEl, () => `${session().category} — round #${session().id}`);
+  bindText(titleEl, () => {
+    const s = session();
+    return s ? `${s.category} — round #${s.id}` : "Loading…";
+  });
 
   const numEl = h("small", { class: "lb-num" });
-  bindText(numEl, () => `#${session().id} · ${session().category.toLowerCase()}`);
+  bindText(numEl, () => {
+    const s = session();
+    return s ? `#${s.id} · ${s.category.toLowerCase()}` : "";
+  });
 
   const stickyEl = h("p", { class: "lb-sticky", "data-bn-region": "play-sticky" });
-  bindText(stickyEl, () => session().category);
+  bindText(stickyEl, () => session()?.category || "");
 
   const subBy = h("strong");
-  bindText(subBy, () => session().submittedBy || "?");
+  bindText(subBy, () => session()?.submittedBy || "?");
   const subEl = h("p", { class: "lb-sub" });
   effect(() => {
     const s = session();
+    if (!s?.words) { subEl.replaceChildren(); return; }
     subEl.replaceChildren(
       document.createTextNode(`${s.words.length} words · ${s.totalLetters} letters · by `),
       subBy,
@@ -410,22 +432,22 @@ export function createPlay({
   effect(() => {
     const s = session();
     const lockedAll = locked();
-    if (!s || lockedAll.length !== s.words.length) return;
+    if (!s?.words || lockedAll.length !== s.words.length) return;
 
     let allInNext = null;
     if (allInMode()) {
       for (let w = 0; w < s.words.length; w++) {
         if (wordSolved()[w]) continue;
-        const ss = openSlots(s.words[w], lockedAll[w]);
-        if (typed()[w].length < ss.length) {
-          allInNext = { wi: w, slotIdx: typed()[w].length };
+        const ss = openSlots(s.words[w], lockedAll[w] || {});
+        if ((typed()[w]?.length || 0) < ss.length) {
+          allInNext = { wi: w, slotIdx: typed()[w]?.length || 0 };
           break;
         }
       }
     }
 
     const wordEls = s.words.map((wordLen, wi) => {
-      const lm = lockedAll[wi];
+      const lm = lockedAll[wi] || {};
       const slots = openSlots(wordLen, lm);
       const isAct = !allInMode() && active() === wi && !wordSolved()[wi] && !casc();
       const wagerSet = new Set(wagers()[wi] || []);
@@ -452,14 +474,14 @@ export function createPlay({
       for (let li = 0; li < wordLen; li++) {
         const lockedLetter = lm[li];
         const slotIdx = slots.indexOf(li);
-        const typedLetter = slotIdx >= 0 ? typed()[wi][slotIdx] : null;
+        const typedLetter = slotIdx >= 0 ? (typed()[wi]?.[slotIdx] ?? null) : null;
         const fbForTile = fbW?.find(f => f.idx === li);
         const isCascDrop = cascDrop() === `${wi}-${li}`;
         const isCascPick = casc() && lockedLetter === undefined && !wordSolved()[wi];
         const isWagered = slotIdx >= 0 && wagerSet.has(slotIdx) && typedLetter;
         const isCursor = allInMode()
           ? (allInNext?.wi === wi && allInNext?.slotIdx === slotIdx)
-          : (isAct && slotIdx === typed()[wi].length);
+          : (isAct && slotIdx === (typed()[wi]?.length || 0));
 
         const cls = ["lb-tile"];
         let display = "";
@@ -639,10 +661,10 @@ export function createPlay({
   bindText(endScore, () => String(score()));
   bindAttr(endScore, "aria-label", () => `Final score ${score()} points`);
   bindText(endShare, () => shareLbl() || "Share result");
-  bindText(endBy, () => session().submittedBy || "?");
+  bindText(endBy, () => session()?.submittedBy || "?");
   bindText(endTitle, () => phase() === "won" ? "Solved" : "House Wins");
   bindClassName(endTitle, () => `lb-ct ${phase() === "won" ? "win" : "lose"}`);
-  bindText(endSub, () => `${session().category}${phase() === "lost" ? " · the answer was" : ""}`);
+  bindText(endSub, () => `${session()?.category || ""}${phase() === "lost" ? " · the answer was" : ""}`);
   bindText(endReveal, () => (reveal() || []).join(" "));
   bindText(endPrimary, () => phase() === "won" ? "Pick another" : "Try again");
   endSecondary.textContent = "Pick another";


### PR DESCRIPTION
## Summary

- **Runtime crash fix:** Guard all `session()` / `locked()` / `typed()` signal accesses in `src/views/play.js` (and the `shareResult` path in `hydrate.js`) with optional chaining + fallback objects. The previous code assumed signals were always populated when reactive bindings re-ran, which produced `undefined is not an object` during transitions (e.g. between rounds, after a navigation back to lobby, on early hydration).
- **Daily game mode:** Wordle-style deterministic daily puzzle. New helpers in `src/lib/game.js` (`dailySeed`, `dailyPuzzle`, `dailyFromGroups`) hash the local YYYY-MM-DD into a stable index. Lobby surfaces a "Today's puzzle" card and badges the daily category in the list. `hydrate.js` adds a one-shot effect that auto-starts today's puzzle on a fresh lobby load (no active session, no resume in flight, on `/`).

## Notes for reviewer

- **Auto-start side effect:** the daily effect redirects fresh `/` visits straight into today's puzzle. The lobby's daily card therefore primarily surfaces on repeat visits within the same load (the `dailyFired` guard prevents re-firing). If you want the lobby to render first and let the user opt-in via the card instead, drop the auto-start effect from `hydrate.js`.
- **Date locality:** `dailySeed` uses local-time `getFullYear/Month/Date`. Two players in different timezones can therefore see different "today" puzzles right around the date boundary. UTC would unify them; local matches a player's intuition. Easy swap if you want UTC.
- **Verification:** `npm run build`, `npm run lint`, `npm run typecheck` all clean. No browser/wrangler-pages-dev verification was done — the daily effect calls `api.startSession`, which only works under `wrangler pages dev`. Worth a manual smoke-test before merge.

## Test plan

- [ ] Load `/` — confirm daily auto-start triggers exactly once and lands on `/play` with today's puzzle.
- [ ] Refresh `/play` mid-round — confirm resume still works and daily auto-start does not interrupt.
- [ ] Navigate back to lobby after a round — confirm daily card renders with today's pick highlighted in the list, and that the daily-category list item resolves to the same puzzle on click.
- [ ] Hard-refresh on `/submit`, `/moderate`, `/admin` — confirm daily auto-start does NOT fire on non-lobby views.
- [ ] Round-end share flow — confirm `shareResult` no longer throws when `session()` is briefly null during transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)