### PR TITLE
fix(ui): card-ify header + keyboard wrap so they stop blending into body

### DIFF
--- a/src/bn/views/layout.js
+++ b/src/bn/views/layout.js
@@ -65,7 +65,7 @@ export default `<!DOCTYPE html>
       :where(svg):not([width]):not([height]){width:1em;height:1em}
       svg{display:block}
       .sr-only{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
-      header[data-bn-region=header]{position:sticky;top:0;z-index:30;width:100%;max-width:540px;margin-bottom:14px;padding:6px 0;background:rgba(12,11,9,.78);backdrop-filter:blur(8px)}
+      header[data-bn-region=header]{position:sticky;top:0;z-index:30;width:100%;max-width:540px;margin-top:4px;margin-bottom:14px;padding:8px 14px;background:rgba(22,20,18,.92);backdrop-filter:blur(8px);border:1px solid #2C2926;border-radius:12px}
       header[data-bn-region=header]>nav{display:flex;align-items:center;justify-content:space-between;gap:8px}
       [data-bn-action=logo]{font-family:'Bebas Neue',sans-serif;font-size:23px;letter-spacing:4px;color:#F0EDE4;display:inline-flex;align-items:center;gap:8px}
       [data-bn-action=logo] em{font-style:normal;color:#E8920A}

--- a/src/styles.css
+++ b/src/styles.css
@@ -404,11 +404,17 @@ body[data-route="play"] #app {
 body { background: radial-gradient(ellipse 110% 55% at 50% 0%, #1c1810 0%, #0C0B09 60%); }
 
 /* HEADER — semantic shell. Drives both SSR first paint and the
-   post-hydration SPA tree (createHeader emits the same shape). */
+   post-hydration SPA tree (createHeader emits the same shape).
+   Card-like: rounded, bordered, inline-padded so contents don't crash
+   into the band's edge. Sits 4px below the viewport top so the
+   border-radius is visible on initial render; sticky pin still works. */
 header[data-bn-region="header"] {
   position: sticky; top: 0; z-index: 30; width: 100%; max-width: 540px;
-  margin-bottom: 14px; padding: 6px 0;
-  background: rgba(12,11,9,.78); backdrop-filter: blur(8px);
+  margin-top: 4px; margin-bottom: 14px;
+  padding: 8px 14px;
+  background: rgba(22,20,18,.92); backdrop-filter: blur(8px);
+  border: 1px solid #2C2926;
+  border-radius: 12px;
 }
 header[data-bn-region="header"] > nav {
   display: flex; align-items: center; justify-content: space-between; gap: 8px;
@@ -697,15 +703,24 @@ main[data-bn-view="play"] section[data-bn-region="bank"] [data-bn-chip="absent"]
   text-decoration: line-through;
 }
 
-/* KEYBOARD WRAP */
+/* KEYBOARD WRAP — fixed-bottom card. Centered, capped at 568px so on
+   wide viewports it reads as a contained surface instead of a black
+   bar floating on the body's near-black gradient. On narrow viewports
+   the calc(100% - 8px) makes it edge-aligned with a 4px hairline
+   margin so the border-radius is visible. */
 main[data-bn-view="play"] section[data-bn-region="keyboard"] {
-  position: fixed; left: 0; right: 0; bottom: 0; z-index: 30;
-  background: #0C0B09; border-top: 1px solid #1F1C18;
-  padding: 8px 6px calc(10px + env(safe-area-inset-bottom,0px));
+  position: fixed; left: 50%; bottom: 0; z-index: 30;
+  transform: translateX(-50%);
+  width: calc(100% - 8px); max-width: 568px;
+  background: #161412;
+  border: 1px solid #2C2926; border-bottom: none;
+  border-top-left-radius: 16px; border-top-right-radius: 16px;
+  box-shadow: 0 -8px 24px rgba(0,0,0,.5);
+  padding: 10px 12px calc(10px + env(safe-area-inset-bottom,0px));
 }
 main[data-bn-view="play"] section[data-bn-region="keyboard"][data-allin] {
-  background: linear-gradient(180deg, rgba(255,77,77,.06) 0%, #0C0B09 30%);
-  border-top-color: rgba(255,77,77,.4);
+  background: linear-gradient(180deg, rgba(255,77,77,.06) 0%, #161412 30%);
+  border-color: rgba(255,77,77,.4); border-bottom: none;
 }
 main[data-bn-view="play"] [data-bn-region="kb-actions"] {
   display: flex; align-items: center; gap: 8px;


### PR DESCRIPTION
## Summary

Both the sticky header and the fixed-bottom keyboard wrap shipped edge-to-edge with the body's near-black gradient — the header had no inline padding or border-radius, and the keyboard wrap was a full-width `#0C0B09` bar against the same `#0C0B09` body bg, so on desktop it read as *\"a black box on an almost-black background.\"*

This PR makes both elements card-like surfaces with real visual hierarchy against the gradient body.

## What changed

### Header
- `margin-top: 4px` — initial breathing room above the card so the rounded top corners are visible.
- `padding: 8px 14px` (was `6px 0`) — content was crashing the band's inline edge.
- `background: rgba(22,20,18,.92)` (was `rgba(12,11,9,.78)`) — too close to the body color to register.
- `border: 1px solid #2C2926` + `border-radius: 12px` — defines the card.

Sticky pin at `top: 0` still works because the 4px margin is above the sticky-stop offset.

### Keyboard wrap
- `left: 50%` + `transform: translateX(-50%)` (was `left: 0; right: 0`) — center the surface.
- `width: calc(100% - 8px); max-width: 568px` — caps at 568px on wide viewports; on phones the calc keeps a 4px hairline gap on each side so the rounded corners are visible.
- `background: #161412` (was `#0C0B09` — same as body).
- `border: 1px solid #2C2926` with `border-bottom: none` — full perimeter except where it sits at the viewport bottom.
- `border-top-left/right-radius: 16px`.
- `box-shadow: 0 -8px 24px rgba(0,0,0,.5)` — subtle lift off the body.
- `[data-allin]` variant gradient updated to match the new bg color.

The 568px cap is intentionally 28px wider than the 540px play card so the keyboard's own padding gives the kb-rows visual breathing room without the bar feeling cramped.

### Critical inline CSS
`src/bn/views/layout.js`'s SSR critical-inline `<style>` was updated in lockstep so first paint matches post-hydration paint and there's no FOUC reshuffle.

## Verification

Patched production styles via Chrome devtools at the target dimensions before committing — the header sits as a proper floating card, the keyboard reads as a contained surface, and there's real visual hierarchy against the gradient body.

`npm run build` clean.

## Test plan

- [x] Build clean.
- [x] In-browser visual check at desktop width (1554px viewport).
- [ ] After merge: spot-check on the deployed site at narrow + wide viewports + verify no scroll-overlap weirdness with the sticky header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)