### PR TITLE
ci: add ci + bundle-size PR gates via DuganLabs reusable workflows

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,32 @@
+name: bundle-size
+
+# Thin caller: delegates to the DuganLabs org reusable workflow that
+# builds the project, measures gzipped JS + CSS output (summed across
+# every chunk in dist/), comments the numbers on the PR, and fails if
+# either total exceeds the budget.
+#
+# Current totals (post-#64): ~31 KB JS gzip, ~6 KB CSS gzip. The 60/40
+# ceiling absorbs reasonable feature growth (~2x headroom on JS, ~6x on
+# CSS) while still catching gross bloat — e.g. adding a heavy dep to
+# the eager graph.
+#
+# Note: this gate measures TOTAL output. The eager-vs-lazy chunk split
+# from #64 is locked separately by tests/build-output.test.js (run via
+# `npm test` from the ci.yml caller), which asserts the lazy view
+# chunks remain dynamic entries and the eager play-boot stays under a
+# 55 KB raw budget.
+#
+# See: https://github.com/DuganLabs/.github/blob/main/.github/workflows/bundle-size.yml
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  size:
+    uses: DuganLabs/.github/.github/workflows/bundle-size.yml@v2
+    with:
+      package-manager: npm
+      js-budget-kb: 60
+      css-budget-kb: 40

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: ci
+
+# Thin caller: delegates to the DuganLabs org reusable workflow that
+# runs lint + typecheck + test against the project's package scripts.
+# See: https://github.com/DuganLabs/.github/blob/main/.github/workflows/ci.yml
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: DuganLabs/.github/.github/workflows/ci.yml@v2
+    with:
+      package-manager: npm


### PR DESCRIPTION
## Summary

Audited t4bs's deployment + CI surface against the reusables already published in [DuganLabs/.github](https://github.com/DuganLabs/.github/tree/main/.github/workflows). The audit turned up **two missing PR gates** and one **separate-PR follow-up**. This PR fills the two gaps using thin callers — no t4bs-local CI plumbing, in keeping with the "BaseNative is source of truth for shared infra" pattern.

## Audit findings

### Already in place (no work needed)

| Workflow | Purpose | Trigger |
|---|---|---|
| [deploy.yml](.github/workflows/deploy.yml) | CF Pages deploy via `cf-deploy.yml@v1` + D1 migrations via `d1-migrate.yml@v1` | push to main |
| [lighthouse.yml](.github/workflows/lighthouse.yml) | Mobile Lighthouse audit via `lighthouse.yml@v2` against prod URL | PR |
| [codeql.yml](.github/workflows/codeql.yml) | security-and-quality CodeQL scan | PR + weekly |
| [wrangler.toml](wrangler.toml) | D1 + KV bindings, Pages output dir, vars (incl. ADMIN_HANDLES seed) | — |

### Gaps filled by this PR

1. **No PR CI** — `npm run lint`, `npm run typecheck`, and `npm test` did not run on PRs. The Lighthouse caller targets the deployed prod URL, so it doesn't catch regressions in the PR's source. PRs could land with failing tests, lint errors, or type errors. Filled by a thin caller of `DuganLabs/.github/.github/workflows/ci.yml@v2` with `package-manager: npm`.
2. **No bundle-size gate** — after the lazy-load split in [#64](https://github.com/DuganLabs/t4bs/pull/64) and the local `tests/build-output.test.js` gate added in [#65](https://github.com/DuganLabs/t4bs/pull/65), there was no PR-level signal showing total gzip JS/CSS or rejecting gross bloat. Filled by a thin caller of `DuganLabs/.github/.github/workflows/bundle-size.yml@v2`.

### Out of scope (follow-up)

- **PR preview deployments**. Production deploys only fire on push to main; PR branches don't get a `*.t4bs.pages.dev` URL from CI. The `cf-deploy.yml` reusable supports a `branch` input but doesn't post the deploy URL back as a PR comment, so wiring this up needs an upstream change to `DuganLabs/.github` first. Better as its own PR.

## Budget choice

`bundle-size.yml` is set to **60 KB JS gzip / 40 KB CSS gzip**. Current totals (post-#64): **~31 KB JS, ~6 KB CSS** — about 2× / 6× headroom. Tight enough to fail on gross bloat, loose enough that ordinary feature work doesn't trip the gate.

Note that this caller measures **total** output across `dist/`. The eager-vs-lazy chunk split is locked separately by [tests/build-output.test.js](tests/build-output.test.js) (run via `npm test` from the new `ci.yml` caller), which asserts the lazy view chunks remain dynamic entries and the eager `play-boot` chunk stays under a 55 KB raw budget. Together the two gates cover both "did the chunk split survive?" and "is the total bundle bloating?"

## Test plan

- [x] `npm ci && npm test` — 161/161 pass
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] Both new workflow YAMLs parse via `js-yaml`
- [x] `v2` tag of `DuganLabs/.github` confirmed to host both `ci.yml` and `bundle-size.yml` reusables
- [ ] After merge: confirm both new gates fire on the next PR (and the bundle-size comment renders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)