### PR TITLE
fix(ssr): defensive null guards in shapePlay + audit-lock the SSR HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint src functions shared",
-    "test": "node --test shared/engine.test.js src/bn/hydrate.test.js src/lib/game.test.js functions/_shared/util.test.js tests/build-output.test.js",
+    "test": "node --test shared/engine.test.js src/bn/hydrate.test.js src/lib/game.test.js functions/_shared/util.test.js tests/build-output.test.js tests/ssr-audit.test.js",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.worker.json",
     "cf:dev": "wrangler pages dev dist --d1=DB --compatibility-date=2024-09-01 --port=8788",
     "cf:deploy": "wrangler pages deploy dist --project-name=t4bs",

--- a/src/bn/server/render.js
+++ b/src/bn/server/render.js
@@ -84,14 +84,21 @@ function lobbyGroups(lobby) {
 /** @param {import('./ssr-context.js').PlaySessionSsr | null} play */
 function shapePlay(play) {
   if (!play) return null;
+  /* Defensive: a partial play context (e.g. a row with null anchors
+     or null words leaking through from the DB) used to throw
+     "x is not iterable" here and 500 the whole SSR response. The
+     happy path always provides arrays — these `|| []` guards just
+     keep a malformed input from cascading. */
+  const anchors = play.anchors || [];
+  const wordsIn = play.words || [];
   const anchorMap = new Map();
-  for (const a of play.anchors) anchorMap.set(`${a.wi}-${a.li}`, a.letter);
-  const words = play.words.map((wordLen, wi) => ({
+  for (const a of anchors) anchorMap.set(`${a.wi}-${a.li}`, a.letter);
+  const words = wordsIn.map((wordLen, wi) => ({
     cells: Array.from({ length: wordLen }, (_, li) => ({
       anchor: anchorMap.get(`${wi}-${li}`) ?? "",
     })),
   }));
-  const wordCount = play.words.length;
+  const wordCount = wordsIn.length;
   return {
     id: play.id,
     category: play.category,

--- a/src/styles.css
+++ b/src/styles.css
@@ -340,13 +340,15 @@ dialog menu[role="tablist"] [role="tab"][aria-selected="true"] {
 /* ENGINE-OWNED HIDE/SHOW (used by signal templates) */
 .is-hidden { display: none !important; }
 
-/* No-JS fallback */
+/* No-JS fallback — index.html's <p class="noscript-msg" role="alert">
+   shown when JS is disabled. The h1 child rule that used to live here
+   was a leftover from an older shape (h1 + p chain inside the
+   noscript) — the post-#54 markup is a single <p>, no h1. */
 .noscript-msg {
   padding: 24px; text-align: center;
   font-family: system-ui, sans-serif;
   color: #F0EDE4; background: #0C0B09;
 }
-.noscript-msg h1 { font-size: 24px; letter-spacing: 4px; margin-bottom: 8px; }
 
 /* ──────────────────────────────────────────────────────────────────
    BASENATIVE SEMANTIC SHELL — drives both the SSR first paint AND the

--- a/tests/ssr-audit.test.js
+++ b/tests/ssr-audit.test.js
@@ -1,0 +1,249 @@
+/* End-to-end audit of every SSR route's rendered HTML. The existing
+   src/bn/hydrate.test.js covers the orchestration layer (renderPage
+   shapes the right context, lobby renders the right anchors, etc.);
+   this file is the spec-level companion: for every canonical route,
+   assert the emitted HTML is well-formed and accessible.
+
+   Each route is rendered with a representative context, then walked
+   through a small set of HTML/a11y rules. Failures point at the
+   specific defect (heading skip, button without name, input without
+   label, etc.) so a regression in a future template change surfaces
+   immediately rather than via a flaky Lighthouse run. */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { renderPage } from "../src/bn/server/render.js";
+
+const ASSETS = { js: "/assets/bn-hydrate.js", css: ["/assets/app.css"] };
+
+function baseCtx(overrides = {}) {
+  return {
+    route: "lobby",
+    pathname: "/",
+    user: null,
+    error: null,
+    lobby: null,
+    play: null,
+    submit: { existingCategories: [] },
+    moderate: { pending: null, forbidden: false },
+    admin: { elevated: null, currentHandle: null, forbidden: false },
+    ...overrides,
+  };
+}
+
+const ROUTE_FIXTURES = {
+  lobby: {
+    pathname: "/",
+    lobby: [
+      { id: 1, category: "ANIMALS", submittedBy: "alice" },
+      { id: 2, category: "ANIMALS", submittedBy: "bob" },
+      { id: 3, category: "FOODS",   submittedBy: "carol" },
+    ],
+  },
+  play: {
+    pathname: "/play",
+    play: {
+      id: 7,
+      category: "CAPITALS",
+      submittedBy: "dave",
+      words: [3, 4],
+      anchors: [{ wi: 0, li: 0, letter: "P" }],
+      totalLetters: 7,
+    },
+  },
+  submit: {
+    pathname: "/submit",
+    submit: { existingCategories: ["ANIMALS", "FOODS"] },
+  },
+  moderate: {
+    pathname: "/moderate",
+    user: { handle: "warren", isModerator: true },
+    moderate: {
+      pending: [{ id: 4, category: "X", phrase: "TEST PHRASE", submittedBy: "alice" }],
+      forbidden: false,
+    },
+  },
+  admin: {
+    pathname: "/admin",
+    user: { handle: "warren", isAdmin: true },
+    admin: {
+      elevated: [{ handle: "alice", role: "moderator" }],
+      currentHandle: "warren",
+      forbidden: false,
+    },
+  },
+  "not-found": {
+    pathname: "/whatever",
+  },
+};
+
+const ROUTES = Object.entries(ROUTE_FIXTURES).map(([route, fixture]) => ({ route, ...fixture }));
+
+/* ── Audit primitives — small enough that the assertion message names
+   what failed without the test having to repeat the rule. ── */
+
+function ariaLabelledbyTargetExists(html) {
+  const m = html.match(/<main[^>]*aria-labelledby="([^"]+)"/);
+  if (!m) return { ok: false, reason: "main missing aria-labelledby" };
+  const id = m[1];
+  if (!new RegExp(`id="${id}"`).test(html)) {
+    return { ok: false, reason: `main aria-labelledby="${id}" but no element with that id` };
+  }
+  return { ok: true };
+}
+
+function headingOrderMonotonic(html) {
+  const headings = [...html.matchAll(/<h([1-6])\b/g)].map(m => Number(m[1]));
+  let prev = 0;
+  for (const lv of headings) {
+    if (lv > prev + 1 && prev !== 0) {
+      return { ok: false, reason: `heading skip: ${headings.join("→")}` };
+    }
+    prev = lv;
+  }
+  return { ok: true, headings };
+}
+
+function anchorsHaveHrefs(html) {
+  /* Require word boundary after `<a` so we don't false-positive on
+     `<article>`. */
+  const m = html.match(/<a\s+(?![^>]*href=)[^>]*>/);
+  if (m) return { ok: false, reason: `<a> without href: ${m[0].slice(0, 80)}` };
+  return { ok: true };
+}
+
+function buttonsInsideFormsHaveType(html) {
+  /* HTML default button type is "submit" — implicit-submit footguns
+     are a perennial PR#-on-the-form regression. */
+  const formStart = html.indexOf("<form");
+  const formEnd   = html.indexOf("</form>");
+  if (formStart < 0 || formEnd <= formStart) return { ok: true };
+  const formContent = html.slice(formStart, formEnd);
+  const m = formContent.match(/<button(?![^>]*\btype=)[^>]*>/);
+  if (m) return { ok: false, reason: `button without type inside <form>: ${m[0].slice(0, 80)}` };
+  return { ok: true };
+}
+
+function inputsHaveLabels(html) {
+  const issues = [];
+  for (const m of html.matchAll(/<input[^>]*\bid="([^"]+)"[^>]*>/g)) {
+    const id = m[1];
+    const inputTag = m[0];
+    /* Skip non-textual inputs (hidden / submit etc.) — only labelable
+       controls need an associated label. */
+    if (/\btype="hidden"|\btype="submit"|\btype="reset"|\btype="button"/.test(inputTag)) continue;
+    const hasLabelFor = new RegExp(`<label[^>]*for="${id}"`).test(html);
+    const hasAriaLabel = /\baria-label=|\baria-labelledby=/.test(inputTag);
+    if (!hasLabelFor && !hasAriaLabel) issues.push(`input id="${id}" missing label`);
+  }
+  return issues.length ? { ok: false, reason: issues.join("; ") } : { ok: true };
+}
+
+function buttonsHaveAccessibleName(html) {
+  const issues = [];
+  /* Greedy-but-non-greedy match across nested tags so wrapper <span>s
+     inside the button still reveal text content. */
+  const re = /<button[^>]*>([\s\S]*?)<\/button>/g;
+  let m;
+  while ((m = re.exec(html))) {
+    const tag = m[0];
+    const innerText = m[1].replace(/<[^>]+>/g, "").trim();
+    const hasAriaName = /\baria-label="[^"]+"|\baria-labelledby="[^"]+"/.test(tag);
+    if (!innerText && !hasAriaName) issues.push(`button no name: ${tag.slice(0, 80)}`);
+  }
+  return issues.length ? { ok: false, reason: issues.join("; ") } : { ok: true };
+}
+
+/* ── Per-route suite ── */
+
+describe("SSR audit — every route emits accessible, spec-conformant HTML", () => {
+  for (const ctx of ROUTES) {
+    describe(`route=${ctx.route}`, () => {
+      const html = renderPage(baseCtx(ctx), ASSETS);
+
+      it("has a doctype and <html lang>", () => {
+        assert.ok(html.startsWith("<!DOCTYPE html>"), "missing doctype");
+        assert.match(html, /<html[^>]*\blang=/);
+      });
+
+      it("has a <title>, viewport meta, and rel=canonical", () => {
+        const title = (html.match(/<title>([^<]*)<\/title>/) || [])[1] || "";
+        assert.ok(title.length >= 5, `weak <title>: "${title}"`);
+        assert.match(html, /name="viewport"/);
+        assert.match(html, /rel="canonical"/);
+      });
+
+      it("has a noscript fallback inside the body", () => {
+        const body = (html.match(/<body[^>]*>([\s\S]*)<\/body>/) || [])[1] || "";
+        assert.match(body, /<noscript>/i, "no <noscript> in body");
+      });
+
+      it("main aria-labelledby points at a real id", () => {
+        const r = ariaLabelledbyTargetExists(html);
+        assert.ok(r.ok, r.reason);
+      });
+
+      it("heading order is monotonic (no skipped levels)", () => {
+        const r = headingOrderMonotonic(html);
+        assert.ok(r.ok, r.reason);
+      });
+
+      it("every <a> has an href", () => {
+        const r = anchorsHaveHrefs(html);
+        assert.ok(r.ok, r.reason);
+      });
+
+      it("every <button> inside a <form> has an explicit type", () => {
+        const r = buttonsInsideFormsHaveType(html);
+        assert.ok(r.ok, r.reason);
+      });
+
+      it("every text-style <input id> has an associated <label for> or aria-label", () => {
+        const r = inputsHaveLabels(html);
+        assert.ok(r.ok, r.reason);
+      });
+
+      it("every <button> has an accessible name (text content or aria-label)", () => {
+        const r = buttonsHaveAccessibleName(html);
+        assert.ok(r.ok, r.reason);
+      });
+    });
+  }
+});
+
+/* ── Defensive shaping — the bug that prompted this whole sweep. ── */
+
+describe("renderPage tolerates partial play contexts", () => {
+  /* shapePlay() used to throw "play.anchors is not iterable" when the
+     incoming play row was missing either field. Adding `|| []` guards
+     makes the SSR robust to malformed input — fail open with an empty
+     grid rather than 500 the whole page. */
+
+  it("does not throw when play.anchors is null", () => {
+    const ctx = baseCtx({
+      route: "play",
+      pathname: "/play",
+      play: { id: 1, category: "X", submittedBy: "a", words: [3], anchors: null, totalLetters: 3 },
+    });
+    assert.doesNotThrow(() => renderPage(ctx, ASSETS));
+  });
+
+  it("does not throw when play.anchors is undefined", () => {
+    const ctx = baseCtx({
+      route: "play",
+      pathname: "/play",
+      play: { id: 1, category: "X", submittedBy: "a", words: [3], totalLetters: 3 },
+    });
+    assert.doesNotThrow(() => renderPage(ctx, ASSETS));
+  });
+
+  it("does not throw when play.words is null", () => {
+    const ctx = baseCtx({
+      route: "play",
+      pathname: "/play",
+      play: { id: 1, category: "X", submittedBy: "a", words: null, anchors: [], totalLetters: 0 },
+    });
+    assert.doesNotThrow(() => renderPage(ctx, ASSETS));
+  });
+});


### PR DESCRIPTION
## Summary

End-to-end SSR audit against every canonical route. Two real defects found, one coverage gap filled, and three checklist items pushed back on as busywork. Tests go from **161 → 218** (all green in 466 ms).

## Audit findings

### Real defects fixed

1. **`shapePlay()` crashes on partial play context** ([src/bn/server/render.js](src/bn/server/render.js)) — `for (const a of play.anchors)` and `play.words.map(...)` assume arrays. A misbehaving DB query (or a future migration that briefly leaves a column null) would throw "x is not iterable" and 500 the entire SSR response. Repro: my audit script crashed the moment I passed a partial play context. Fix: `|| []` guards on both reads — fail open with an empty grid instead.
2. **Dead `.noscript-msg h1` CSS rule** ([src/styles.css](src/styles.css)) — its only consumer (index.html's no-JS fallback) was rewritten in [#54](https://github.com/DuganLabs/t4bs/pull/54) from `<h1>+<p>` into a single `<p>`, so there's no `h1` child for the rule to match.

### New: SSR audit test ([tests/ssr-audit.test.js](tests/ssr-audit.test.js))

For every canonical route (lobby/play/submit/moderate/admin/not-found), render with a representative context and walk the emitted HTML through:

| Rule | Why |
|---|---|
| Doctype + `<html lang>` | spec + screen-reader language |
| `<title>` non-empty, viewport meta, rel=canonical | SEO + responsive |
| `<noscript>` fallback inside `<body>` | no-JS UX |
| `<main aria-labelledby>` resolves to a real id | broken accessible name otherwise |
| Heading order is monotonic | screen-reader navigation |
| Every `<a>` has an `href` | otherwise it's not a link |
| Every `<button>` inside a `<form>` has an explicit `type` | HTML default is `submit` — silent footgun |
| Every text-style `<input id>` has an associated `<label for>` or aria-label | a11y |
| Every `<button>` has an accessible name | a11y |

Plus three regression tests for the `shapePlay` crash (null anchors, undefined anchors, null words). The same audit logic is what surfaced the crash — locking it in tests means a future template edit gets the same checks for free.

### Audit checklist items pushed back as busywork

- **"Migrate `sr-only` / `noscript-msg` to `data-bn-*` attributes"** — `sr-only` is a universal a11y idiom (Tailwind, Bootstrap, the WAI examples). Migrating its 13 consumers to `data-bn-region="sr-only"` would be churn for zero functional or perf benefit AND would actively reduce affordance for new contributors who recognise the standard class. `noscript-msg` has one consumer; same zero-benefit profile. `bn-sr-only` and `bn-admin-*` are upstream-owned (`@basenative/admin/components`) and not migrable from this repo. **These aren't `lb-*` leftovers — that family ended at #63.**

### Audit observations NOT acted on (product decisions)

- **SSR / SPA lobby divergence**: the SSR template shows the old browse-by-category list (anchor links per category, usable without JS); the SPA shows daily-only mode after #51. Whether no-JS users should also see the daily-only restriction is a product question (better to let no-JS users play *something* vs. matching the JS-on flow), not a bug to silently fix.
- **Submit form has no `action`/`method`**: a no-JS user filling out the form gets a silent dead-end submit. Same product call as above.

I'd be happy to scope these as separate PRs once you decide which way you want them.

## Test plan

- [x] `npm test` — 218/218 pass (was 161/161; +57 new across `tests/ssr-audit.test.js`)
- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] Manually re-ran the original ad-hoc audit script (the one that found the `shapePlay` crash) post-fix — no longer throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)